### PR TITLE
feat: Implement catalog navigation through links

### DIFF
--- a/pact/contents/library-website-library-catalog.json
+++ b/pact/contents/library-website-library-catalog.json
@@ -41,11 +41,168 @@
               }
             ]
           },
+          "_links": {
+            "first": {
+              "href": "http://localhost:8080/api/v1/catalog?page=0&size=10"
+            },
+            "last": {
+              "href": "http://localhost:8080/api/v1/catalog?page=6&size=10"
+            },
+            "next": {
+              "href": "http://localhost:8080/api/v1/catalog?page=1&size=10"
+            }
+          },
           "page": {
             "number": 0,
             "size": 10,
             "total_elements": 67,
             "total_pages": 7
+          }
+        },
+        "headers": {
+          "Content-Type": "application/json"
+        },
+        "matchingRules": {
+          "body": {
+            "$._embedded.authors": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$._embedded.authors[*].id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$"
+                }
+              ]
+            },
+            "$._embedded.books": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "max": 10
+                }
+              ]
+            },
+            "$._embedded.books[*].authors": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "type",
+                  "min": 1
+                }
+              ]
+            },
+            "$._embedded.books[*].authors[*]": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "regex",
+                  "regex": "^[0-9a-f]{8}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{4}\\b-[0-9a-f]{12}$"
+                }
+              ]
+            },
+            "$.page.number": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.page.size": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.page.total_elements": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            },
+            "$.page.total_pages": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "integer"
+                }
+              ]
+            }
+          }
+        },
+        "status": 206
+      }
+    },
+    {
+      "description": "Specific website page request",
+      "providerStates": [
+        {
+          "name": "Catalog contains books"
+        }
+      ],
+      "request": {
+        "method": "GET",
+        "path": "/api/v1/catalog",
+        "query": {
+          "page": [
+            "1"
+          ],
+          "size": [
+            "25"
+          ]
+        }
+      },
+      "response": {
+        "body": {
+          "_embedded": {
+            "authors": [
+              {
+                "id": "99287cef-2c8c-4a4d-a82e-f1a8452dcfe2",
+                "name": "Jean-Jacques Rousseau"
+              }
+            ],
+            "books": [
+              {
+                "authors": [
+                  "99287cef-2c8c-4a4d-a82e-f1a8452dcfe2"
+                ],
+                "summary": "Paru en 1762, le Contrat social, ...",
+                "title": "Du contrat social"
+              }
+            ]
+          },
+          "_links": {
+            "first": {
+              "href": "http://localhost:8080/api/v1/catalog?page=0&size=25"
+            },
+            "last": {
+              "href": "http://localhost:8080/api/v1/catalog?page=3&size=25"
+            },
+            "next": {
+              "href": "http://localhost:8080/api/v1/catalog?page=2&size=25"
+            },
+            "prev": {
+              "href": "http://localhost:8080/api/v1/catalog?page=0&size=25"
+            }
+          },
+          "page": {
+            "number": 1,
+            "size": 25,
+            "total_elements": 67,
+            "total_pages": 3
           }
         },
         "headers": {

--- a/website/src/main/java/org/adhuc/library/website/catalog/CatalogClient.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/CatalogClient.java
@@ -1,12 +1,12 @@
 package org.adhuc.library.website.catalog;
 
-import org.springframework.data.domain.Page;
+import org.adhuc.library.website.support.pagination.NavigablePage;
 import org.springframework.data.domain.Pageable;
 
 public interface CatalogClient {
 
-    Page<Book> listBooks();
+    NavigablePage<Book> listBooks();
 
-    Page<Book> listBooks(Pageable pageable);
+    NavigablePage<Book> listBooks(NavigablePage<Book> current, String linkName);
 
 }

--- a/website/src/main/java/org/adhuc/library/website/catalog/CatalogController.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/CatalogController.java
@@ -1,23 +1,83 @@
 package org.adhuc.library.website.catalog;
 
+import org.adhuc.library.website.support.pagination.NavigablePage;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.SessionAttributes;
+
+import java.util.List;
+import java.util.Optional;
 
 @Controller
+@SessionAttributes("booksPage")
 public class CatalogController {
 
     private final CatalogClient catalogClient;
+    private final NavigationSession navigationSession;
 
-    CatalogController(CatalogClient catalogClient) {
+    // First and last links must be displayed only if there is respectively a previous or a next page
+    // This is due to the fact that Spring HATEOAS considers that the first and last links must always be available in response
+    private final List<PageAttribute> pageAttributes = List.of(
+            new PageAttribute("first", List.of("first", "prev"), "firstPageLinkName"),
+            new PageAttribute("prev", "previousPageLinkName"),
+            new PageAttribute("next", "nextPageLinkName"),
+            new PageAttribute("last", List.of("last", "next"), "lastPageLinkName")
+    );
+
+    CatalogController(CatalogClient catalogClient, NavigationSession navigationSession) {
         this.catalogClient = catalogClient;
+        this.navigationSession = navigationSession;
     }
 
     @GetMapping("/catalog")
-    public String catalog(Model model) {
-        var booksPage = catalogClient.listBooks();
-        model.addAttribute("books", booksPage.getContent());
+    public String catalog(Model model, @RequestParam(name = "link", required = false) String linkToFollow) {
+        try {
+            return getBooksPage(linkToFollow)
+                    .map(page -> browsePage(model, page))
+                    .orElseGet(this::redirectToDefaultPage);
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("message", e.getMessage());
+            return "error";
+        }
+    }
+
+    private Optional<NavigablePage<Book>> getBooksPage(String linkToFollow) {
+        if (linkToFollow != null) {
+            // The navigation session may not find the current page if the server has been restarted
+            return navigationSession.currentPage()
+                    .map(currentPage -> catalogClient.listBooks(currentPage, linkToFollow));
+        }
+        return Optional.of(catalogClient.listBooks());
+    }
+
+    private String browsePage(Model model, NavigablePage<Book> booksPage) {
+        navigationSession.switchPage(booksPage);
+        fillModel(model, booksPage);
         return "catalog/root";
+    }
+
+    private void fillModel(Model model, NavigablePage<Book> booksPage) {
+        model.addAttribute("books", booksPage.getContent());
+        pageAttributes.forEach(pageAttribute -> pageAttribute.addToModel(booksPage, model));
+    }
+
+    private String redirectToDefaultPage() {
+        navigationSession.clearCurrentPage();
+        return "redirect:/catalog";
+    }
+
+    private record PageAttribute(String linkName, List<String> neededLinks, String attributeName) {
+        PageAttribute(String linkName, String attributeName) {
+            this(linkName, List.of(linkName), attributeName);
+        }
+
+        void addToModel(NavigablePage<?> page, Model model) {
+            if (neededLinks.stream().allMatch(page::hasLink)) {
+                model.addAttribute(attributeName, linkName);
+            }
+        }
     }
 
 }

--- a/website/src/main/java/org/adhuc/library/website/catalog/NavigationSession.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/NavigationSession.java
@@ -1,0 +1,35 @@
+package org.adhuc.library.website.catalog;
+
+import org.adhuc.library.website.support.pagination.NavigablePage;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static org.springframework.context.annotation.ScopedProxyMode.TARGET_CLASS;
+import static org.springframework.web.context.WebApplicationContext.SCOPE_SESSION;
+
+@Component
+@Scope(
+        value = SCOPE_SESSION,
+        proxyMode = TARGET_CLASS
+)
+public class NavigationSession {
+
+    private NavigablePage<Book> currentPage;
+
+    public Optional<NavigablePage<Book>> currentPage() {
+        return Optional.ofNullable(currentPage);
+    }
+
+    public void switchPage(NavigablePage<Book> page) {
+        if (page == null) {
+            throw new IllegalArgumentException("Cannot switch to null page");
+        }
+        this.currentPage = page;
+    }
+
+    public void clearCurrentPage() {
+        this.currentPage = null;
+    }
+}

--- a/website/src/main/java/org/adhuc/library/website/catalog/internal/BooksPage.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/internal/BooksPage.java
@@ -3,22 +3,49 @@ package org.adhuc.library.website.catalog.internal;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.adhuc.library.website.catalog.Book;
-import org.springframework.data.domain.PageImpl;
+import org.adhuc.library.website.support.pagination.NavigablePageImpl;
 import org.springframework.data.domain.PageRequest;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @JsonDeserialize
-public class BooksPage extends PageImpl<Book> {
+public class BooksPage extends NavigablePageImpl<Book> {
 
-    public BooksPage(@JsonProperty("page") PageAttributes page, @JsonProperty("_embedded") EmbeddedValues embedded) {
-        super(embedded.convertedBooks(), PageRequest.of(page.number(), page.size()), page.totalElements());
+    public BooksPage(@JsonProperty("page") PageAttributes page,
+                     @JsonProperty("_links") Links links,
+                     @JsonProperty("_embedded") EmbeddedValues embedded) {
+        super(embedded.convertedBooks(), PageRequest.of(page.number(), page.size()), page.totalElements(), links.converted());
     }
 
     public record PageAttributes(int size,
                                  @JsonProperty("total_elements") int totalElements,
                                  @JsonProperty("total_pages") int totalPages,
                                  int number) {
+    }
+
+    public record Links(LinkValue first, @JsonProperty("prev") LinkValue previous, LinkValue next, LinkValue last) {
+        List<Link> converted() {
+            return Stream.of(
+                            converted("first", first),
+                            converted("prev", previous),
+                            converted("next", next),
+                            converted("last", last)
+                    )
+                    .filter(Optional::isPresent)
+                    .map(Optional::get)
+                    .toList();
+        }
+
+        private Optional<Link> converted(String name, LinkValue linkValue) {
+            return Optional.ofNullable(linkValue)
+                    .map(LinkValue::href)
+                    .map(href -> new Link(name, href));
+        }
+    }
+
+    public record LinkValue(String href) {
     }
 
     public record EmbeddedValues(List<BookDto> books, List<AuthorDto> authors) {

--- a/website/src/main/java/org/adhuc/library/website/catalog/internal/CatalogRestClient.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/internal/CatalogRestClient.java
@@ -2,8 +2,8 @@ package org.adhuc.library.website.catalog.internal;
 
 import org.adhuc.library.website.catalog.Book;
 import org.adhuc.library.website.catalog.CatalogClient;
+import org.adhuc.library.website.support.pagination.NavigablePage;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -21,14 +21,25 @@ class CatalogRestClient implements CatalogClient {
     }
 
     @Override
-    public Page<Book> listBooks() {
+    public NavigablePage<Book> listBooks() {
         return listBooks(PageRequest.of(0, 10));
     }
 
+    NavigablePage<Book> listBooks(Pageable pageable) {
+        return listBooks("/api/v1/catalog?page={page}&size={size}", pageable.getPageNumber(), pageable.getPageSize());
+    }
+
     @Override
-    public Page<Book> listBooks(Pageable pageable) {
+    public NavigablePage<Book> listBooks(NavigablePage<Book> current, String linkName) {
+        if (!current.hasLink(linkName)) {
+            throw new IllegalArgumentException("Cannot browse to page through link " + linkName + " from current");
+        }
+        return listBooks(current.getLink(linkName).orElseThrow());
+    }
+
+    private NavigablePage<Book> listBooks(String uri, Object... uriVariables) {
         return restClient.get()
-                .uri("/api/v1/catalog?page={page}&size={size}", pageable.getPageNumber(), pageable.getPageSize())
+                .uri(uri, uriVariables)
                 .accept(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .body(BooksPage.class);

--- a/website/src/main/java/org/adhuc/library/website/support/pagination/NavigablePage.java
+++ b/website/src/main/java/org/adhuc/library/website/support/pagination/NavigablePage.java
@@ -1,0 +1,13 @@
+package org.adhuc.library.website.support.pagination;
+
+import org.springframework.data.domain.Page;
+
+import java.util.Optional;
+
+public interface NavigablePage<T> extends Page<T> {
+
+    boolean hasLink(String linkName);
+
+    Optional<String> getLink(String linkName);
+
+}

--- a/website/src/main/java/org/adhuc/library/website/support/pagination/NavigablePageImpl.java
+++ b/website/src/main/java/org/adhuc/library/website/support/pagination/NavigablePageImpl.java
@@ -1,0 +1,41 @@
+package org.adhuc.library.website.support.pagination;
+
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.util.Assert;
+
+import java.util.List;
+import java.util.Optional;
+
+public class NavigablePageImpl<T> extends PageImpl<T> implements NavigablePage<T> {
+
+    private final List<Link> links;
+
+    public NavigablePageImpl(List<T> content, Pageable pageable, long total, List<Link> links) {
+        super(content, pageable, total);
+        this.links = links != null ? List.copyOf(links) : List.of();
+    }
+
+    @Override
+    public boolean hasLink(String linkName) {
+        Assert.hasText(linkName, "Link name must be set");
+        return links.stream()
+                .anyMatch(link -> link.correspondsTo(linkName));
+    }
+
+    @Override
+    public Optional<String> getLink(String linkName) {
+        Assert.hasText(linkName, "Link name must be set");
+        return links.stream()
+                .filter(link -> link.correspondsTo(linkName))
+                .map(Link::href)
+                .findFirst();
+    }
+
+    public record Link(String name, String href) {
+        boolean correspondsTo(String name) {
+            return this.name.equals(name);
+        }
+    }
+
+}

--- a/website/src/main/resources/templates/catalog/root.html
+++ b/website/src/main/resources/templates/catalog/root.html
@@ -5,6 +5,13 @@
 
 <h2>Library catalog</h2>
 
+<div>
+    <span><a th:if="${firstPageLinkName != null}" th:href="@{/catalog(link=${firstPageLinkName})}" title="First" class="fa fa-fast-backward"></a></span>
+    <span><a th:if="${previousPageLinkName != null}" th:href="@{/catalog(link=${previousPageLinkName})}" title="Previous" class="fa fa-step-backward"></a></span>
+    <span><a th:if="${nextPageLinkName != null}" th:href="@{/catalog(link=${nextPageLinkName})}" title="Next" class="fa fa-step-forward"></a></span>
+    <span><a th:if="${lastPageLinkName != null}" th:href="@{/catalog(link=${lastPageLinkName})}" title="Last" class="fa fa-fast-forward"></a></span>
+</div>
+
 <table id="catalog" class="table table-striped">
     <thead>
     <tr>

--- a/website/src/main/resources/templates/error.html
+++ b/website/src/main/resources/templates/error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'error')}">
+
+<body>
+<h2>Something happened...</h2>
+<p th:text="${message}">Exception message</p>
+</body>
+
+</html>

--- a/website/src/test/java/org/adhuc/library/website/catalog/BooksMother.java
+++ b/website/src/test/java/org/adhuc/library/website/catalog/BooksMother.java
@@ -25,5 +25,10 @@ public final class BooksMother {
             List.of(new Author(UUID.fromString("060d74f4-1d42-4087-b4ef-07dd00bb559c"), "David Graeber")),
             "Dans la société moderne, beaucoup d'employés consacrent leur vie à des tâches inutiles et vides de sens. C'est ce que David Graeber appelle les \"bullshit jobs\" - ou \"jobs à la con\". L'auteur en cherche l'origine et en détaille les conséquences : dépression, anxiété, effondrement de l'estime de soi... Il en appelle à une révolte du salarié moderne ainsi qu'à une vaste réorganisation des valeurs, qui placerait le travail créatif et aidant au coeur de notre culture et ferait de la technologie un outil de libération plutôt que d'asservissement assouvissant enfin notre soif de sens et d'épanouissement."
     );
+    public static final Book HAMLET = new Book(
+            "Hamlet",
+            List.of(new Author(UUID.fromString("34100743-dcd0-45da-8142-8f4e650dd365"), "William Shakespeare")),
+            "\"Sit down awhile, And let us once again assail your ears, That are so fortified against our story What we have two nights seen...\" The Tragedy of Hamlet, Prince of Denmark, often shortened to Hamlet, is a tragedy written by William Shakespeare at an uncertain date between 1599 and 1602. Set in the Kingdom of Denmark, the play dramatises the revenge Prince Hamlet is called to wreak upon his uncle, Claudius, by the ghost of Hamlet's father, King Hamlet. Claudius had murdered his own brother and seized the throne, also marrying his deceased brother's widow. Hamlet is Shakespeare's longest play, and is among the most powerful and influential tragedies in English literature, with a story capable of \"seemingly endless retelling and adaptation by others\". The play likely was one of Shakespeare's most popular works during his lifetime, and still ranks among his most performed."
+    );
 
 }

--- a/website/src/test/java/org/adhuc/library/website/catalog/CatalogControllerTests.java
+++ b/website/src/test/java/org/adhuc/library/website/catalog/CatalogControllerTests.java
@@ -1,18 +1,29 @@
 package org.adhuc.library.website.catalog;
 
+import org.adhuc.library.website.support.pagination.NavigablePageImpl;
+import org.adhuc.library.website.support.pagination.NavigablePageImpl.Link;
+import org.hamcrest.Matcher;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Stream;
 
 import static org.adhuc.library.website.catalog.BooksMother.*;
-import static org.mockito.Mockito.when;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -20,23 +31,203 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DisplayName("Catalog controller should")
 class CatalogControllerTests {
 
+    private static final String FIRST_PAGE_LINK_ATTRIBUTE = "firstPageLinkName";
+    private static final String PREVIOUS_PAGE_LINK_ATTRIBUTE = "previousPageLinkName";
+    private static final String NEXT_PAGE_LINK_ATTRIBUTE = "nextPageLinkName";
+    private static final String LAST_PAGE_LINK_ATTRIBUTE = "lastPageLinkName";
+
+    private static final List<Book> PAGE_CONTENT = List.of(
+            DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU, A_DANCE_WITH_DRAGONS, BULLSHIT_JOBS
+    );
+
     @Autowired
     private MockMvc mvc;
     @MockitoBean
     private CatalogClient catalogClient;
+    @MockitoBean
+    private NavigationSession navigationSession;
 
     @Test
-    @DisplayName("provide the catalog page")
-    void catalogPage() throws Exception {
-        var content = List.of(
-                DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU, A_DANCE_WITH_DRAGONS, BULLSHIT_JOBS
-        );
-        when(catalogClient.listBooks()).thenReturn(new PageImpl<>(content, PageRequest.of(0, 10), 4));
+    @DisplayName("provide the catalog default page")
+    void catalogDefaultPage() throws Exception {
+        var page = new NavigablePageImpl<>(PAGE_CONTENT, PageRequest.of(0, 10), 4, List.of());
+        when(catalogClient.listBooks()).thenReturn(page);
 
         mvc.perform(get("/catalog"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("catalog/root"))
-                .andExpect(model().attribute("books", content));
+                .andExpect(model().attribute("books", PAGE_CONTENT))
+                .andExpect(model().attributeDoesNotExist(
+                        FIRST_PAGE_LINK_ATTRIBUTE,
+                        PREVIOUS_PAGE_LINK_ATTRIBUTE,
+                        NEXT_PAGE_LINK_ATTRIBUTE,
+                        LAST_PAGE_LINK_ATTRIBUTE
+                ));
+
+        verify(catalogClient).listBooks();
+        verifyNoMoreInteractions(catalogClient);
+        verify(navigationSession).switchPage(same(page));
+        verifyNoMoreInteractions(navigationSession);
+    }
+
+    @ParameterizedTest
+    @MethodSource("linksProvider")
+    @DisplayName("provide the catalog default page including links")
+    void catalogDefaultPageWithLinks(List<Link> links, Map<String, Matcher<String>> linksAttributesMatcher) throws Exception {
+        var page = new NavigablePageImpl<>(PAGE_CONTENT, PageRequest.of(0, 10), 4, links);
+        when(catalogClient.listBooks()).thenReturn(page);
+
+        var result = mvc.perform(get("/catalog"))
+                .andExpect(status().isOk())
+                .andExpect(view().name("catalog/root"))
+                .andExpect(model().attribute("books", PAGE_CONTENT));
+        for (var attribute : linksAttributesMatcher.keySet()) {
+            var matcher = linksAttributesMatcher.get(attribute);
+            result.andExpect(model().attribute(attribute, matcher));
+        }
+
+        verify(catalogClient).listBooks();
+        verifyNoMoreInteractions(catalogClient);
+        verify(navigationSession).switchPage(same(page));
+        verifyNoMoreInteractions(navigationSession);
+    }
+
+    private static Stream<Arguments> linksProvider() {
+        var first = new Link("first", "linkToFirst");
+        var previous = new Link("prev", "linkToPrevious");
+        var next = new Link("next", "linkToNext");
+        var last = new Link("last", "linkToLast");
+        return Stream.of(
+                Arguments.of(
+                        List.of(new Link("unknown", "unknownLink")),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(first),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(first, previous),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("first")),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("prev")),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(previous),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("prev")),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(next),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("next")),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(last),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(next, last),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("next")),
+                                LAST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("last"))
+                        )
+                ),
+                Arguments.of(
+                        List.of(first, previous, next, last),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("first")),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("prev")),
+                                NEXT_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("next")),
+                                LAST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("last"))
+                        )
+                ),
+                Arguments.of(
+                        List.of(first, previous),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("first")),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("prev")),
+                                NEXT_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                LAST_PAGE_LINK_ATTRIBUTE, nullValue()
+                        )
+                ),
+                Arguments.of(
+                        List.of(next, last),
+                        Map.of(
+                                FIRST_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                PREVIOUS_PAGE_LINK_ATTRIBUTE, nullValue(),
+                                NEXT_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("next")),
+                                LAST_PAGE_LINK_ATTRIBUTE, both(notNullValue()).and(equalTo("last"))
+                        )
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"first", "prev", "next", "last"})
+    @DisplayName("provide the catalog default page when navigating through a link, without previous navigation session")
+    void catalogPageWithoutPreviousSession(String linkToFollow) throws Exception {
+        var page = new NavigablePageImpl<>(PAGE_CONTENT, PageRequest.of(0, 10), 4, List.of());
+        when(catalogClient.listBooks()).thenReturn(page);
+
+        mvc.perform(get("/catalog").param("link", linkToFollow))
+                .andExpect(status().isFound())
+                .andExpect(view().name("redirect:/catalog"));
+
+        verifyNoInteractions(catalogClient);
+        verify(navigationSession).currentPage();
+        verify(navigationSession).clearCurrentPage();
+        verifyNoMoreInteractions(navigationSession);
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"first", "prev", "next", "last"})
+    @DisplayName("provide the catalog page when navigating through a link, with previous navigation session")
+    void catalogPageWithPageInPreviousSession(String linkToFollow) throws Exception {
+        var previousPage = new NavigablePageImpl<>(List.of(A_DANCE_WITH_DRAGONS),
+                PageRequest.of(0, 10), 4, List.of());
+        var page = new NavigablePageImpl<>(PAGE_CONTENT, PageRequest.of(0, 10), 4, List.of());
+        when(navigationSession.currentPage()).thenReturn(Optional.of(previousPage));
+        when(catalogClient.listBooks(any(), any())).thenReturn(page);
+
+        mvc.perform(get("/catalog").param("link", linkToFollow))
+                .andExpect(status().isOk())
+                .andExpect(view().name("catalog/root"))
+                .andExpect(model().attribute("books", PAGE_CONTENT));
+
+        verify(catalogClient).listBooks(any(), eq(linkToFollow));
+        verifyNoMoreInteractions(catalogClient);
+        verify(navigationSession).currentPage();
+        verify(navigationSession).switchPage(same(page));
+        verifyNoMoreInteractions(navigationSession);
     }
 
 }

--- a/website/src/test/java/org/adhuc/library/website/catalog/internal/CatalogRestClientTests.java
+++ b/website/src/test/java/org/adhuc/library/website/catalog/internal/CatalogRestClientTests.java
@@ -1,6 +1,9 @@
 package org.adhuc.library.website.catalog.internal;
 
 import org.adhuc.library.website.catalog.Book;
+import org.adhuc.library.website.support.pagination.NavigablePage;
+import org.adhuc.library.website.support.pagination.NavigablePageImpl;
+import org.adhuc.library.website.support.pagination.NavigablePageImpl.Link;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -20,8 +23,10 @@ import java.util.stream.Stream;
 
 import static org.adhuc.library.website.catalog.BooksMother.*;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.springframework.http.HttpStatus.PARTIAL_CONTENT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestToUriTemplate;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 
@@ -57,13 +62,17 @@ class CatalogRestClientTests {
             s.assertThat(actual.getTotalPages()).isEqualTo(7);
             s.assertThat(actual.getNumber()).isEqualTo(0);
             s.assertThat(actual.getContent().size()).isEqualTo(10);
+            s.assertThat(actual.hasLink("first")).isTrue();
+            s.assertThat(actual.hasLink("prev")).isFalse();
+            s.assertThat(actual.hasLink("next")).isTrue();
+            s.assertThat(actual.hasLink("last")).isTrue();
         });
     }
 
     @ParameterizedTest
     @MethodSource("pageProvider")
     @DisplayName("list books for a page")
-    void getPage(int page, int size, Resource response, int expectedTotalPages, int expectedSize) {
+    void getPage(int page, int size, Resource response, int expectedTotalPages, int expectedSize, boolean hasPrev, boolean hasNext) {
         mockServer.expect(requestToUriTemplate("http://localhost:12345/test/api/v1/catalog?page={page}&size={size}", page, size)).andRespond(
                 withStatus(PARTIAL_CONTENT).body(response).contentType(APPLICATION_JSON)
         );
@@ -75,17 +84,21 @@ class CatalogRestClientTests {
             s.assertThat(actual.getTotalPages()).isEqualTo(expectedTotalPages);
             s.assertThat(actual.getNumber()).isEqualTo(page);
             s.assertThat(actual.getContent().size()).isEqualTo(expectedSize);
+            s.assertThat(actual.hasLink("first")).isTrue();
+            s.assertThat(actual.hasLink("prev")).isEqualTo(hasPrev);
+            s.assertThat(actual.hasLink("next")).isEqualTo(hasNext);
+            s.assertThat(actual.hasLink("last")).isTrue();
         });
     }
 
     static Stream<Arguments> pageProvider() {
         var resourceLoader = new DefaultResourceLoader();
         return Stream.of(
-                Arguments.of(0, 10, resourceLoader.getResource("classpath:client/catalog/page-0-size-10.json"), 7, 10),
-                Arguments.of(1, 10, resourceLoader.getResource("classpath:client/catalog/page-1-size-10.json"), 7, 10),
-                Arguments.of(6, 10, resourceLoader.getResource("classpath:client/catalog/page-6-size-10.json"), 7, 7),
-                Arguments.of(0, 50, resourceLoader.getResource("classpath:client/catalog/page-0-size-50.json"), 2, 50),
-                Arguments.of(1, 50, resourceLoader.getResource("classpath:client/catalog/page-1-size-50.json"), 2, 17)
+                Arguments.of(0, 10, resourceLoader.getResource("classpath:client/catalog/page-0-size-10.json"), 7, 10, false, true),
+                Arguments.of(1, 10, resourceLoader.getResource("classpath:client/catalog/page-1-size-10.json"), 7, 10, true, true),
+                Arguments.of(6, 10, resourceLoader.getResource("classpath:client/catalog/page-6-size-10.json"), 7, 7, true, false),
+                Arguments.of(0, 50, resourceLoader.getResource("classpath:client/catalog/page-0-size-50.json"), 2, 50, false, true),
+                Arguments.of(1, 50, resourceLoader.getResource("classpath:client/catalog/page-1-size-50.json"), 2, 17, true, false)
         );
     }
 
@@ -116,6 +129,117 @@ class CatalogRestClientTests {
                         List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU, A_DANCE_WITH_DRAGONS),
                         List.of(BULLSHIT_JOBS)
                 )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("pageBooksFromLinkProvider")
+    @DisplayName("list books for a link from the previously browsed page with expected books contained and non expected books not contained")
+    void getPageFromLink(NavigablePage<Book> currentPage, String linkName, String url, Resource response, List<Book> expectedBooks, List<Book> nonExpectedBooks) {
+        mockServer.expect(requestTo(url)).andRespond(
+                withStatus(PARTIAL_CONTENT).body(response).contentType(APPLICATION_JSON)
+        );
+
+        var actual = catalogRestClient.listBooks(currentPage, linkName);
+        assertThat(actual.getContent()).containsAll(expectedBooks).doesNotContainAnyElementsOf(nonExpectedBooks);
+    }
+
+    static Stream<Arguments> pageBooksFromLinkProvider() {
+        var resourceLoader = new DefaultResourceLoader();
+
+        var page0Size10 = new NavigablePageImpl<>(
+                List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU),
+                PageRequest.of(0, 10), 67,
+                List.of(
+                        new Link("first", "http://localhost:12345/test/api/v1/catalog?page=0&size=10"),
+                        new Link("next", "http://localhost:12345/test/api/v1/catalog?page=1&size=10"),
+                        new Link("last", "http://localhost:12345/test/api/v1/catalog?page=6&size=10")
+                )
+        );
+        var page1Size10 = new NavigablePageImpl<>(
+                List.of(A_DANCE_WITH_DRAGONS),
+                PageRequest.of(1, 10), 67,
+                List.of(
+                        new Link("first", "http://localhost:12345/test/api/v1/catalog?page=0&size=10"),
+                        new Link("prev", "http://localhost:12345/test/api/v1/catalog?page=0&size=10"),
+                        new Link("next", "http://localhost:12345/test/api/v1/catalog?page=2&size=10"),
+                        new Link("last", "http://localhost:12345/test/api/v1/catalog?page=6&size=10")
+                )
+        );
+        var page1Size50 = new NavigablePageImpl<>(
+                List.of(BULLSHIT_JOBS),
+                PageRequest.of(1, 50), 67,
+                List.of(
+                        new Link("first", "http://localhost:12345/test/api/v1/catalog?page=0&size=50"),
+                        new Link("prev", "http://localhost:12345/test/api/v1/catalog?page=0&size=50"),
+                        new Link("last", "http://localhost:12345/test/api/v1/catalog?page=1&size=50")
+                )
+        );
+
+        return Stream.of(
+                Arguments.of(page1Size10, "first",
+                        "http://localhost:12345/test/api/v1/catalog?page=0&size=10",
+                        resourceLoader.getResource("classpath:client/catalog/page-0-size-10.json"),
+                        List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU),
+                        List.of(A_DANCE_WITH_DRAGONS)
+                ),
+                Arguments.of(page1Size10, "prev",
+                        "http://localhost:12345/test/api/v1/catalog?page=0&size=10",
+                        resourceLoader.getResource("classpath:client/catalog/page-0-size-10.json"),
+                        List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU),
+                        List.of(A_DANCE_WITH_DRAGONS)
+                ),
+                Arguments.of(page0Size10, "next",
+                        "http://localhost:12345/test/api/v1/catalog?page=1&size=10",
+                        resourceLoader.getResource("classpath:client/catalog/page-1-size-10.json"),
+                        List.of(A_DANCE_WITH_DRAGONS),
+                        List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU)
+                ),
+                Arguments.of(page0Size10, "last",
+                        "http://localhost:12345/test/api/v1/catalog?page=6&size=10",
+                        resourceLoader.getResource("classpath:client/catalog/page-6-size-10.json"),
+                        List.of(HAMLET),
+                        List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU)
+                ),
+                Arguments.of(page1Size50, "prev",
+                        "http://localhost:12345/test/api/v1/catalog?page=0&size=50",
+                        resourceLoader.getResource("classpath:client/catalog/page-0-size-50.json"),
+                        List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU, A_DANCE_WITH_DRAGONS),
+                        List.of(BULLSHIT_JOBS)
+                )
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("pageBooksFromUnknownLinkProvider")
+    @DisplayName("refuse listing books for an unknown link from the previously browsed page")
+    void getPageFromUnknownLink(NavigablePage<Book> currentPage, String linkName) {
+        assertThrows(IllegalArgumentException.class, () -> catalogRestClient.listBooks(currentPage, linkName));
+    }
+
+    static Stream<Arguments> pageBooksFromUnknownLinkProvider() {
+        var page0Size10 = new NavigablePageImpl<>(
+                List.of(DU_CONTRAT_SOCIAL, LA_FRATERNITE_DE_L_ANNEAU),
+                PageRequest.of(0, 10), 67,
+                List.of(
+                        new Link("first", "http://localhost:12345/test/api/v1/catalog?page=0&size=10"),
+                        new Link("next", "http://localhost:12345/test/api/v1/catalog?page=1&size=10"),
+                        new Link("last", "http://localhost:12345/test/api/v1/catalog?page=6&size=10")
+                )
+        );
+        var page6Size10 = new NavigablePageImpl<>(
+                List.of(HAMLET),
+                PageRequest.of(6, 10), 67,
+                List.of(
+                        new Link("first", "http://localhost:12345/test/api/v1/catalog?page=0&size=10"),
+                        new Link("prev", "http://localhost:12345/test/api/v1/catalog?page=5&size=10"),
+                        new Link("last", "http://localhost:12345/test/api/v1/catalog?page=6&size=10")
+                )
+        );
+
+        return Stream.of(
+                Arguments.of(page0Size10, "prev"),
+                Arguments.of(page6Size10, "next")
         );
     }
 

--- a/website/src/test/resources/client/catalog/page-0-size-10.json
+++ b/website/src/test/resources/client/catalog/page-0-size-10.json
@@ -17,7 +17,7 @@
         "summary": "Paru en 1762, le Contrat social, en affirmant le principe de souveraineté du peuple, a constitué un tournant décisif pour la modernité et s'est imposé comme un des textes majeurs de la philosophie politique. Il a aussi acquis le statut de monument, plus célèbre que connu, plus révéré - ou honni - qu'interrogé. Retrouver, dans les formules fameuses et les pages d'anthologie, le mouvement de la réflexion et les questions vives qui nourrissent une œuvre beaucoup plus problématique qu'affirmative, c'est découvrir une pensée qui se tient au plus près des préoccupations d'aujourd'hui : comment intégrer les intérêts de tous dans la détermination de l'intérêt commun ? Comment lutter contre la pente de tout gouvernement à déposséder les citoyens de la souveraineté ? Comment former en chacun ce sentiment d'obligation sans lequel le lien social se défait ?\n",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782081275232"
+            "href": "http://localhost:12345/api/v1/books/9782081275232"
           }
         }
       },
@@ -31,7 +31,7 @@
         "summary": "Paru en 1755, le Discours sur l'origine et les fondements de l'inégalité parmi les hommes peut être considéré comme la matrice de l'oeuvre morale et politique de Rousseau : il y affirme sa stature de philosophe, l'originalité de sa voix, la force de son \"système\". Résoudre le problème posé par l'Académie de Dijon - \"quelle est la source de l'inégalité parmi les hommes et si elle est autorisée par la loi naturelle ? \"-, en d'autres termes expliquer que riches et puissants dominent leurs semblables sur lesquels ils n'ont pas de réelle supériorité, exige aux yeux de Rousseau de poser à nouveaux frais la question \"qu'est-ce que l'homme ? \".\nPour cela, il faut comprendre comment s'est formée sa \"nature actuelle\", si éloignée de ce que serait son état de nature : \"Si je me suis étendu si longtemps sur la supposition de cette condition primitive, c'est qu'ayant d'anciennes erreurs et des préjugés invétérés à détruire, j'ai cru devoir creuser jusqu'à la racine.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782081275256"
+            "href": "http://localhost:12345/api/v1/books/9782081275256"
           }
         }
       },
@@ -45,7 +45,7 @@
         "summary": "La publication de l'Emile, en 1762, restitue au problème de l'éducation sa place centrale en philosophie. De ses premiers mois jusqu'à la rencontre amoureuse, Emile est suivi dans chaque étape, à travers des expériences qui attestent d'abord le souci de considérer « l'enfant dans l'enfant », au lieu de le sortir de son âge. Rousseau montre qu'il est possible d'éduquer un homme selon la nature et de quelle façon les vices et l'inégalité caractérisent désormais la condition humaine : double enjeu qui constitue sa « théorie de l'homme ».\nLa richesse incomparable de ce maître-livre tient aussi aux tensions qui le parcourent. Rousseau refuse le péché originel mais il doit rendre raison du mal et de la souffrance que ce dogme interdisait d'ignorer; il critique les philosophes de son temps mais il pousse à ses limites leur méthode empiriste; il proclame: «je hais les livres», mais il fournit le panorama le plus juste et le plus instruit de la culture du XVIIIe siècle, en face de l'Encyclopédie et, pour partie, contre elle.\nParus ensemble, Emile et le Contrat social furent condamnés à Paris puis à Genève: la force du traité d'éducation n'échappa pas aux censeurs, même si Rousseau prétendait ne livrer que « les rêveries d'un visionnaire ». Car la forme même de la fiction arrache l'ouvrage aux circonstances : pas plus que ses lecteurs des Lumières, nous ne sommes à l'abri de ses leçons. ",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782081206922"
+            "href": "http://localhost:12345/api/v1/books/9782081206922"
           }
         }
       },
@@ -59,7 +59,7 @@
         "summary": "Je forme une entreprise qui n'eut jamais d'exemple et dont l'exécution n'aura point d'imitateur. Je veux montrer à mes semblables un homme dans toute la vérité de la nature; et cet homme ce sera moi. Moi, seul. Je sens mon cœur et je connais les hommes. Je ne suis fait comme aucun de ceux que j'ai vus; j'ose croire n'être fait comme aucun de ceux qui existent. Si je ne vaux pas mieux, au moins je suis autre. Si la nature a bien ou mal fait de briser le moule dans lequel elle m'a jeté, c'est ce dont on ne peut juger qu'après m'avoir lu. ",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782070399697"
+            "href": "http://localhost:12345/api/v1/books/9782070399697"
           }
         }
       },
@@ -73,7 +73,7 @@
         "summary": "\"J'ai vu les moeurs de mon temps, et j'ai publié ces lettres\" : c'est par ces mots que l'\"éditeur\" Rousseau ouvre La Nouvelle Héloïse, correspondance amoureuse entre Julie d'Etange et son précepteur Saint-Preux. Sur les rives du lac Léman, ces \"belles âmes\" forment une petite société idéale, où priment les passions douces et la sincérité du sentiment, à l'écart des maux de la civilisation. Dans la lignée des Lettres persanes de Montesquieu, Rousseau conçoit son oeuvre comme un laboratoire d'idées nouvelles, qui concentre les questionnements de son époque sur l'homme et ses passions.\nRoman d'amour, chant élégiaque, mais aussi fiction expérimentale au croisement de l'anthropologie et de la politique : La Nouvelle Héloïse, plus grand succès de librairie de son temps, consacre avec éclat les noces du roman et de la philosophie au XVIIIe siècle. ",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782081409842"
+            "href": "http://localhost:12345/api/v1/books/9782081409842"
           }
         }
       },
@@ -87,7 +87,7 @@
         "summary": "Dans un paisible village du Comté, le jeune Frodo est sur le point de recevoir un cadeau qui changera sa vie à jamais : l'Anneau de Pouvoir. Forgé par Sauron au coeur de la Montagne du Feu, on croyait l'Anneau perdu depuis qu'un homme l'avait arraché au Seigneur des Ténèbres avant de le chasser hors du monde. A présent, de noirs présages s'étendent à nouveau sur la Terre du Milieu, les créatures maléfiques se multiplient et, dans les Montagnes de Brume, les Orques traquent les Nains.\nL'ennemi veut récupérer son bien afin de dominer le monde ; l'Œil de Sauron est désormais pointé sur le Comté. Heureusement Gandalf les a devancés. S'ils font vite, Frodo et lui parviendront peut-être à détruire l'Anneau à temps. Chef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur.\nCette traduction de Daniel Lauzon prend en compte la dernière version du texte anglais, les indications laissées par Tolkien à l'intention des traducteurs et les découvertes permises par les publications posthumes proposées par Christopher Tolkien. Ce volume contient 18 illustrations d'Alan Lee, ainsi que deux cartes en couleur de la Terre du Milieu et du Comté. ",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782267046885"
+            "href": "http://localhost:12345/api/v1/books/9782267046885"
           }
         }
       },
@@ -101,7 +101,7 @@
         "summary": "La Fraternité de l'Anneau poursuit son voyage vers la Montagne du Feu où l'Anneau Unique fut forgé, et où Frodo a pour mission de le détruire. Cette quête terrible est parsemée d'embûches : Gandalf a disparu dans les Mines de la Moria et Boromir a succombé au pouvoir de l'Anneau. Frodo et Sam se sont échappés afin de poursuivre leur voyage jusqu'au coeur du Mordor. A présent, ils cheminent seuls dans la désolation qui entoure le pays de Sauron – mais c'est sans compter la mystérieuse silhouette qui les suit partout où ils vont.\nChef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur. Cette traduction de Daniel Lauzon prend en compte la dernière version du texte anglais, les indications laissées par Tolkien à l'intention des traducteurs et les découvertes permises par les publications posthumes proposées par Christopher Tolkien.\nCe volume contient 16 illustrations d'Alan Lee, ainsi qu'une carte en couleur de la Terre du Milieu.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782267046892"
+            "href": "http://localhost:12345/api/v1/books/9782267046892"
           }
         }
       },
@@ -115,7 +115,7 @@
         "summary": "Alors que les armées de Sauron se rassemblent et que son ombre maléfique s'étend de plus en plus en Terre du Milieu, Hommes, Nains, Elfes et Ents unissent leurs forces pour se battre contre les Ténèbres. Gandalf, quant à lui, élabore une stratégie désespérée afin de triompher du mal. Le Mordor s'est armé, ses créatures malfaisantes se sont multipliées, la riposte se prépare. Si l'Anneau tombe entre les mains du Seigneur des Ténèbres, qui pourra l'arrêter ? Tous les espoirs reposent sur Frodo et Sam, qui peinent à atteindre la Montagne du Feu afin de détruire, une bonne fois pour toutes, l'Anneau de Sauron.\nChef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782267046908"
+            "href": "http://localhost:12345/api/v1/books/9782267046908"
           }
         }
       },
@@ -129,7 +129,7 @@
         "summary": "Bilbo, comme tous les hobbits, est un petit être paisible et sans histoires. Son quotidien est bouleversé un beau jour, lorsque Gandalf le magicien et treize nains barbus l'entraînent dans un voyage périlleux. C'est le début d'une grande aventure, d'une fantastique quête au trésor semée d'embûches et d'épreuves, qui mènera Bilbo jusqu'à la Montagne Solitaire gardée par le dragon Smaug...",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782266339667"
+            "href": "http://localhost:12345/api/v1/books/9782266339667"
           }
         }
       },
@@ -143,7 +143,7 @@
         "summary": "Composé de récits allant des Jours Anciens de la Terre du Milieu jusqu'à la fin de la Guerre de l'Anneau, en passant par le Second Age et la montée en puissance de Sauron, Le Silmarillion est au coeur de l'univers imaginé par J. R. R. Tolkien. Ces histoires se déroulent à une époque où Morgoth, le premier Seigneur des Ténèbres, habite la Terre du Milieu et où les Elfes lui font la guerre dans sa forteresse d'Angband pour récupérer les Silmarils.\nCes trois joyaux contenant la dernière lumière pure du Valinor ont été dérobés par Morgoth puis sertis dans sa couronne de fer. Ces contes sont accompagnés de plusieurs oeuvres plus courtes. L'Ainulindalë est un mythe de la Création tandis que la Valaquenta décrit la nature et les pouvoirs des dieux. L'Akallabêth raconte la destruction du grand royaume insulaire de Númenor à la fin du Second Age et Les Anneaux du Pouvoir relate les grands événements de la fin du Troisième Age, que raconte également Le Seigneur des Anneaux.\nJ. R. R. Tolkien n'a pas pu publier Le Silmarillion de son vivant, car il a évolué avec lui. Il a donc laissé à son fils Christopher le soin de faire paraître cette oeuvre à partir de nombreux manuscrits et de rendre publiable la grande vision de son père, terminant ainsi l'oeuvre littéraire de toute une vie. Cette édition spéciale présente sous une forme nouvelle ce premier pas fondamental dans l'édition posthume par Christopher Tolkien des volumes concernant la Terre du Milieu, début de quarante années d'une carrière illustre, avec la publication de plus de vingt livres célébrant l'héritage de son père.\nOn retrouvera aussi dans ce volume une lettre de J. R. R. Tolkien, écrite en 1951, qui fournit une passionnante exposition des Ages précédents, et près de 50 peintures en couleurs de Ted Nasmith, dont certaines apparaissent ici pour la première fois.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782267044706"
+            "href": "http://localhost:12345/api/v1/books/9782267044706"
           }
         }
       }
@@ -154,7 +154,7 @@
         "name": "Jean-Jacques Rousseau",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"
+            "href": "http://localhost:12345/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"
           }
         }
       },
@@ -163,7 +163,7 @@
         "name": "John Ronald Reuel Tolkien",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/authors/d8d94b64-603d-4fae-90dd-5296cde7fa2c"
+            "href": "http://localhost:12345/api/v1/authors/d8d94b64-603d-4fae-90dd-5296cde7fa2c"
           }
         }
       }
@@ -171,16 +171,16 @@
   },
   "_links": {
     "first": {
-      "href": "http://localhost:8080/api/v1/catalog?page=0&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=0&size=10"
     },
     "self": {
-      "href": "http://localhost:8080/api/v1/catalog?page=0&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=0&size=10"
     },
     "next": {
-      "href": "http://localhost:8080/api/v1/catalog?page=1&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=1&size=10"
     },
     "last": {
-      "href": "http://localhost:8080/api/v1/catalog?page=6&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=6&size=10"
     }
   }
 }

--- a/website/src/test/resources/client/catalog/page-0-size-50.json
+++ b/website/src/test/resources/client/catalog/page-0-size-50.json
@@ -14,7 +14,7 @@
       "summary" : "Paru en 1762, le Contrat social, en affirmant le principe de souveraineté du peuple, a constitué un tournant décisif pour la modernité et s'est imposé comme un des textes majeurs de la philosophie politique. Il a aussi acquis le statut de monument, plus célèbre que connu, plus révéré - ou honni - qu'interrogé. Retrouver, dans les formules fameuses et les pages d'anthologie, le mouvement de la réflexion et les questions vives qui nourrissent une œuvre beaucoup plus problématique qu'affirmative, c'est découvrir une pensée qui se tient au plus près des préoccupations d'aujourd'hui : comment intégrer les intérêts de tous dans la détermination de l'intérêt commun ? Comment lutter contre la pente de tout gouvernement à déposséder les citoyens de la souveraineté ? Comment former en chacun ce sentiment d'obligation sans lequel le lien social se défait ?\n",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782081275232"
+          "href" : "http://localhost:12345/api/v1/books/9782081275232"
         }
       }
     }, {
@@ -25,7 +25,7 @@
       "summary" : "Paru en 1755, le Discours sur l'origine et les fondements de l'inégalité parmi les hommes peut être considéré comme la matrice de l'oeuvre morale et politique de Rousseau : il y affirme sa stature de philosophe, l'originalité de sa voix, la force de son \"système\". Résoudre le problème posé par l'Académie de Dijon - \"quelle est la source de l'inégalité parmi les hommes et si elle est autorisée par la loi naturelle ? \"-, en d'autres termes expliquer que riches et puissants dominent leurs semblables sur lesquels ils n'ont pas de réelle supériorité, exige aux yeux de Rousseau de poser à nouveaux frais la question \"qu'est-ce que l'homme ? \".\nPour cela, il faut comprendre comment s'est formée sa \"nature actuelle\", si éloignée de ce que serait son état de nature : \"Si je me suis étendu si longtemps sur la supposition de cette condition primitive, c'est qu'ayant d'anciennes erreurs et des préjugés invétérés à détruire, j'ai cru devoir creuser jusqu'à la racine.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782081275256"
+          "href" : "http://localhost:12345/api/v1/books/9782081275256"
         }
       }
     }, {
@@ -36,7 +36,7 @@
       "summary" : "La publication de l'Emile, en 1762, restitue au problème de l'éducation sa place centrale en philosophie. De ses premiers mois jusqu'à la rencontre amoureuse, Emile est suivi dans chaque étape, à travers des expériences qui attestent d'abord le souci de considérer « l'enfant dans l'enfant », au lieu de le sortir de son âge. Rousseau montre qu'il est possible d'éduquer un homme selon la nature et de quelle façon les vices et l'inégalité caractérisent désormais la condition humaine : double enjeu qui constitue sa « théorie de l'homme ».\nLa richesse incomparable de ce maître-livre tient aussi aux tensions qui le parcourent. Rousseau refuse le péché originel mais il doit rendre raison du mal et de la souffrance que ce dogme interdisait d'ignorer; il critique les philosophes de son temps mais il pousse à ses limites leur méthode empiriste; il proclame: «je hais les livres», mais il fournit le panorama le plus juste et le plus instruit de la culture du XVIIIe siècle, en face de l'Encyclopédie et, pour partie, contre elle.\nParus ensemble, Emile et le Contrat social furent condamnés à Paris puis à Genève: la force du traité d'éducation n'échappa pas aux censeurs, même si Rousseau prétendait ne livrer que « les rêveries d'un visionnaire ». Car la forme même de la fiction arrache l'ouvrage aux circonstances : pas plus que ses lecteurs des Lumières, nous ne sommes à l'abri de ses leçons. ",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782081206922"
+          "href" : "http://localhost:12345/api/v1/books/9782081206922"
         }
       }
     }, {
@@ -47,7 +47,7 @@
       "summary" : "Je forme une entreprise qui n'eut jamais d'exemple et dont l'exécution n'aura point d'imitateur. Je veux montrer à mes semblables un homme dans toute la vérité de la nature; et cet homme ce sera moi. Moi, seul. Je sens mon cœur et je connais les hommes. Je ne suis fait comme aucun de ceux que j'ai vus; j'ose croire n'être fait comme aucun de ceux qui existent. Si je ne vaux pas mieux, au moins je suis autre. Si la nature a bien ou mal fait de briser le moule dans lequel elle m'a jeté, c'est ce dont on ne peut juger qu'après m'avoir lu. ",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070399697"
+          "href" : "http://localhost:12345/api/v1/books/9782070399697"
         }
       }
     }, {
@@ -58,7 +58,7 @@
       "summary" : "\"J'ai vu les moeurs de mon temps, et j'ai publié ces lettres\" : c'est par ces mots que l'\"éditeur\" Rousseau ouvre La Nouvelle Héloïse, correspondance amoureuse entre Julie d'Etange et son précepteur Saint-Preux. Sur les rives du lac Léman, ces \"belles âmes\" forment une petite société idéale, où priment les passions douces et la sincérité du sentiment, à l'écart des maux de la civilisation. Dans la lignée des Lettres persanes de Montesquieu, Rousseau conçoit son oeuvre comme un laboratoire d'idées nouvelles, qui concentre les questionnements de son époque sur l'homme et ses passions.\nRoman d'amour, chant élégiaque, mais aussi fiction expérimentale au croisement de l'anthropologie et de la politique : La Nouvelle Héloïse, plus grand succès de librairie de son temps, consacre avec éclat les noces du roman et de la philosophie au XVIIIe siècle. ",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782081409842"
+          "href" : "http://localhost:12345/api/v1/books/9782081409842"
         }
       }
     }, {
@@ -69,7 +69,7 @@
       "summary" : "Dans un paisible village du Comté, le jeune Frodo est sur le point de recevoir un cadeau qui changera sa vie à jamais : l'Anneau de Pouvoir. Forgé par Sauron au coeur de la Montagne du Feu, on croyait l'Anneau perdu depuis qu'un homme l'avait arraché au Seigneur des Ténèbres avant de le chasser hors du monde. A présent, de noirs présages s'étendent à nouveau sur la Terre du Milieu, les créatures maléfiques se multiplient et, dans les Montagnes de Brume, les Orques traquent les Nains.\nL'ennemi veut récupérer son bien afin de dominer le monde ; l'Œil de Sauron est désormais pointé sur le Comté. Heureusement Gandalf les a devancés. S'ils font vite, Frodo et lui parviendront peut-être à détruire l'Anneau à temps. Chef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur.\nCette traduction de Daniel Lauzon prend en compte la dernière version du texte anglais, les indications laissées par Tolkien à l'intention des traducteurs et les découvertes permises par les publications posthumes proposées par Christopher Tolkien. Ce volume contient 18 illustrations d'Alan Lee, ainsi que deux cartes en couleur de la Terre du Milieu et du Comté. ",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782267046885"
+          "href" : "http://localhost:12345/api/v1/books/9782267046885"
         }
       }
     }, {
@@ -80,7 +80,7 @@
       "summary" : "La Fraternité de l'Anneau poursuit son voyage vers la Montagne du Feu où l'Anneau Unique fut forgé, et où Frodo a pour mission de le détruire. Cette quête terrible est parsemée d'embûches : Gandalf a disparu dans les Mines de la Moria et Boromir a succombé au pouvoir de l'Anneau. Frodo et Sam se sont échappés afin de poursuivre leur voyage jusqu'au coeur du Mordor. A présent, ils cheminent seuls dans la désolation qui entoure le pays de Sauron – mais c'est sans compter la mystérieuse silhouette qui les suit partout où ils vont.\nChef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur. Cette traduction de Daniel Lauzon prend en compte la dernière version du texte anglais, les indications laissées par Tolkien à l'intention des traducteurs et les découvertes permises par les publications posthumes proposées par Christopher Tolkien.\nCe volume contient 16 illustrations d'Alan Lee, ainsi qu'une carte en couleur de la Terre du Milieu.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782267046892"
+          "href" : "http://localhost:12345/api/v1/books/9782267046892"
         }
       }
     }, {
@@ -91,7 +91,7 @@
       "summary" : "Alors que les armées de Sauron se rassemblent et que son ombre maléfique s'étend de plus en plus en Terre du Milieu, Hommes, Nains, Elfes et Ents unissent leurs forces pour se battre contre les Ténèbres. Gandalf, quant à lui, élabore une stratégie désespérée afin de triompher du mal. Le Mordor s'est armé, ses créatures malfaisantes se sont multipliées, la riposte se prépare. Si l'Anneau tombe entre les mains du Seigneur des Ténèbres, qui pourra l'arrêter ? Tous les espoirs reposent sur Frodo et Sam, qui peinent à atteindre la Montagne du Feu afin de détruire, une bonne fois pour toutes, l'Anneau de Sauron.\nChef-d'oeuvre de la fantasy, découverte d'un monde imaginaire, de sa géographie, de son histoire et de ses langues, mais aussi réflexion sur le pouvoir et la mort, Le Seigneur des Anneaux est sans équivalent par sa puissance d'évocation, son souffle et son ampleur.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782267046908"
+          "href" : "http://localhost:12345/api/v1/books/9782267046908"
         }
       }
     }, {
@@ -102,7 +102,7 @@
       "summary" : "Bilbo, comme tous les hobbits, est un petit être paisible et sans histoires. Son quotidien est bouleversé un beau jour, lorsque Gandalf le magicien et treize nains barbus l'entraînent dans un voyage périlleux. C'est le début d'une grande aventure, d'une fantastique quête au trésor semée d'embûches et d'épreuves, qui mènera Bilbo jusqu'à la Montagne Solitaire gardée par le dragon Smaug...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782266339667"
+          "href" : "http://localhost:12345/api/v1/books/9782266339667"
         }
       }
     }, {
@@ -113,7 +113,7 @@
       "summary" : "Composé de récits allant des Jours Anciens de la Terre du Milieu jusqu'à la fin de la Guerre de l'Anneau, en passant par le Second Age et la montée en puissance de Sauron, Le Silmarillion est au coeur de l'univers imaginé par J. R. R. Tolkien. Ces histoires se déroulent à une époque où Morgoth, le premier Seigneur des Ténèbres, habite la Terre du Milieu et où les Elfes lui font la guerre dans sa forteresse d'Angband pour récupérer les Silmarils.\nCes trois joyaux contenant la dernière lumière pure du Valinor ont été dérobés par Morgoth puis sertis dans sa couronne de fer. Ces contes sont accompagnés de plusieurs oeuvres plus courtes. L'Ainulindalë est un mythe de la Création tandis que la Valaquenta décrit la nature et les pouvoirs des dieux. L'Akallabêth raconte la destruction du grand royaume insulaire de Númenor à la fin du Second Age et Les Anneaux du Pouvoir relate les grands événements de la fin du Troisième Age, que raconte également Le Seigneur des Anneaux.\nJ. R. R. Tolkien n'a pas pu publier Le Silmarillion de son vivant, car il a évolué avec lui. Il a donc laissé à son fils Christopher le soin de faire paraître cette oeuvre à partir de nombreux manuscrits et de rendre publiable la grande vision de son père, terminant ainsi l'oeuvre littéraire de toute une vie. Cette édition spéciale présente sous une forme nouvelle ce premier pas fondamental dans l'édition posthume par Christopher Tolkien des volumes concernant la Terre du Milieu, début de quarante années d'une carrière illustre, avec la publication de plus de vingt livres célébrant l'héritage de son père.\nOn retrouvera aussi dans ce volume une lettre de J. R. R. Tolkien, écrite en 1951, qui fournit une passionnante exposition des Ages précédents, et près de 50 peintures en couleurs de Ted Nasmith, dont certaines apparaissent ici pour la première fois.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782267044706"
+          "href" : "http://localhost:12345/api/v1/books/9782267044706"
         }
       }
     }, {
@@ -124,7 +124,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290208878"
+          "href" : "http://localhost:12345/api/v1/books/9782290208878"
         }
       }
     }, {
@@ -135,7 +135,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290215661"
+          "href" : "http://localhost:12345/api/v1/books/9782290215661"
         }
       }
     }, {
@@ -146,7 +146,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221686"
+          "href" : "http://localhost:12345/api/v1/books/9782290221686"
         }
       }
     }, {
@@ -157,7 +157,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221693"
+          "href" : "http://localhost:12345/api/v1/books/9782290221693"
         }
       }
     }, {
@@ -168,7 +168,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221709"
+          "href" : "http://localhost:12345/api/v1/books/9782290221709"
         }
       }
     }, {
@@ -179,7 +179,7 @@
       "summary" : "Winter is coming. Such is the stern motto of House Stark, the northernmost of the fiefdoms that owe allegiance to King Robert Baratheon in far-off King’s Landing. There Eddard Stark of Winterfell rules in Robert’s name. There his family dwells in peace and comfort: his proud wife, Catelyn; his sons Robb, Brandon, and Rickon; his daughters Sansa and Arya; and his bastard son, Jon Snow. Far to the north, behind the towering Wall, lie savage Wildings and worse—unnatural things relegated to myth during the centuries-long summer, but proving all too real and all too deadly in the turning of the season.\n\nYet a more immediate threat lurks to the south, where Jon Arryn, the Hand of the King, has died under mysterious circumstances. Now Robert is riding north to Winterfell, bringing his queen, the lovely but cold Cersei, his son, the cruel, vainglorious Prince Joffrey, and the queen’s brothers Jaime and Tyrion of the powerful and wealthy House Lannister—the first a swordsman without equal, the second a dwarf whose stunted stature belies a brilliant mind. All are heading for Winterfell and a fateful encounter that will change the course of kingdoms.\n\nMeanwhile, across the Narrow Sea, Prince Viserys, heir of the fallen House Targaryen, which once ruled all of Westeros, schemes to reclaim the throne with an army of barbarian Dothraki—whose loyalty he will purchase in the only coin left to him: his beautiful yet innocent sister, Daenerys.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553103540"
+          "href" : "http://localhost:12345/api/v1/books/9780553103540"
         }
       }
     }, {
@@ -190,7 +190,7 @@
       "summary" : "Time is out of joint. The summer of peace and plenty, ten years long, is drawing to a close, and the harsh, chill winter approaches like an angry beast. Two great leaders—Lord Eddard Stark and Robert Baratheon—who held sway over an age of enforced peace are dead . . . victims of royal treachery. Now, from the ancient citadel of Dragonstone to the forbidding shores of Winterfell, chaos reigns, as pretenders to the Iron Throne of the Seven Kingdoms prepare to stake their claims through tempest, turmoil, and war.\n\nAs a prophecy of doom cuts across the sky—a comet the color of blood and flame—six factions struggle for control of a divided land. Eddard’s son Robb has declared himself King in the North. In the south, Joffrey, the heir apparent, rules in name only, victim of the scheming courtiers who teem over King’s Landing. Robert’s two brothers each seek their own dominion, while a disfavored house turns once more to conquest. And a continent away, an exiled queen, the Mother of Dragons, risks everything to lead her precious brood across a hard hot desert to win back the crown that is rightfully hers.\n\nA Clash of Kings transports us into a magnificent, forgotten land of revelry and revenge, wizardry and warfare. It is a tale in which maidens cavort with madmen, brother plots against brother, and the dead rise to walk in the night. Here a princess masquerades as an orphan boy; a knight of the mind prepares a poison for a treacherous sorceress; and wild men descend from the Mountains of the Moon to ravage the countryside.\n\nAgainst a backdrop of incest and fratricide, alchemy and murder, the price of glory may be measured in blood. And the spoils of victory may just go to the men and women possessed of the coldest steel . . . and the coldest hearts. For when rulers clash, all of the land feels the tremors.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553108033"
+          "href" : "http://localhost:12345/api/v1/books/9780553108033"
         }
       }
     }, {
@@ -201,7 +201,7 @@
       "summary" : "Of the five contenders for power, one is dead, another in disfavor, and still the wars rage. Joffrey sits on the Iron Throne, the uneasy ruler of the Seven Kingdoms. His most bitter rival, Lord Stannis, stands defeated and disgraced, victim of the sorceress who holds him in her thrall. Young Robb still rules the North from the fortress of Riverrun. Meanwhile, making her way across a blood-drenched continent is the exiled queen, Daenerys, mistress of the only three dragons left in the world. As opposing forces maneuver for the final showdown, an army of barbaric wildlings arrives from the outermost limits of civilization, accompanied by a supernatural army of the living dead. As the future of the land hangs in the balance, no one will rest until the Seven Kingdoms have exploded in a veritable storm of swords...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553106633"
+          "href" : "http://localhost:12345/api/v1/books/9780553106633"
         }
       }
     }, {
@@ -212,7 +212,7 @@
       "summary" : "After centuries of bitter strife, the seven powers dividing the land have beaten one another into an uneasy truce. But it’s not long before the survivors, outlaws, renegades, and carrion eaters of the Seven Kingdoms gather. Now, as the human crows assemble over a banquet of ashes, daring new plots and dangerous new alliances are formed while surprising faces—some familiar, others only just appearing—emerge from an ominous twilight of past struggles and chaos to take up the challenges of the terrible times ahead. Nobles and commoners, soldiers and sorcerers, assassins and sages, are coming together to stake their fortunes . . . and their lives. For at a feast for crows, many are the guests—but only a few are the survivors.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553801507"
+          "href" : "http://localhost:12345/api/v1/books/9780553801507"
         }
       }
     }, {
@@ -223,7 +223,7 @@
       "summary" : "In the aftermath of a colossal battle, the future of the Seven Kingdoms hangs in the balance—beset by newly emerging threats from every direction. In the east, Daenerys Targaryen, the last scion of House Targaryen, rules with her three dragons as queen of a city built on dust and death. But Daenerys has thousands of enemies, and many have set out to find her. As they gather, one young man embarks upon his own quest for the queen, with an entirely different goal in mind.\n\nFleeing from Westeros with a price on his head, Tyrion Lannister, too, is making his way to Daenerys. But his newest allies in this quest are not the rag-tag band they seem, and at their heart lies one who could undo Daenerys’s claim to Westeros forever.\n\nMeanwhile, to the north lies the mammoth Wall of ice and stone—a structure only as strong as those guarding it. There, Jon Snow, 998th Lord Commander of the Night’s Watch, will face his greatest challenge. For he has powerful foes not only within the Watch but also beyond, in the land of the creatures of ice.\n\nFrom all corners, bitter conflicts reignite, intimate betrayals are perpetrated, and a grand cast of outlaws and priests, soldiers and skinchangers, nobles and slaves, will face seemingly insurmountable obstacles. Some will fail, others will grow in the strength of darkness. But in a time of rising restlessness, the tides of destiny and politics will lead inevitably to the greatest dance of all.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553801477"
+          "href" : "http://localhost:12345/api/v1/books/9780553801477"
         }
       }
     }, {
@@ -234,7 +234,7 @@
       "summary" : "En ce début de treizième millénaire, l'Empire n'a jamais été aussi puissant, aussi étendu à travers toute la galaxie. C'est clans sa capitale, Trantor, que l'éminent savant Hari Seldon invente la psychohistoire, une science nouvelle permettant de prédire l'avenir. Grâce à elle, Seldon prévoit l'effondrement de l'Empire d'ici trois siècles, suivi d'une ère de ténèbres de trente mille ans. Réduire cette période à mille ans est peut-être possible, à condition de mener à terme son projet : la Fondation, chargée de rassembler toutes les connaissances humaines.\nUne entreprise visionnaire qui rencontre de nombreux et puissants détracteurs... Récompensé par le prix Hugo de la \"meilleure série de science-fiction de tous les temps Le cycle de Fondation est l'œuvre socle de la S-F moderne, celle que tous les amateurs du genre ont lue ou liront un jour.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070360536"
+          "href" : "http://localhost:12345/api/v1/books/9782070360536"
         }
       }
     }, {
@@ -245,7 +245,7 @@
       "summary" : "Tandis que les crises qui secouent l'Empire redoublent de violence et annoncent son effondrement définitif, la Fondation créée par le psychohistorien Hari Seldon pour sauvegarder la civilisation devient de plus en plus puissante, suscitant naturellement convoitise et visées annexionnistes. En tout premier lieu, celles de Bel Riose, jeune général qui voit dans les secrets détenus par la Fondation le moyen de monter sur le trône.\nC'est alors qu'apparaît un mystérieux et invincible conquérant, surnommé le Mulet, que le plan de Seldon n'avait pas prévu...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070360550"
+          "href" : "http://localhost:12345/api/v1/books/9782070360550"
         }
       }
     }, {
@@ -256,7 +256,7 @@
       "summary" : "Conçue par le psychohistorien Hari Seldon pour restreindre l'ère de chaos résultant de la décadence de l'Empire galactique, la Fondation est désormais aux mains du Mulet, un mutant imprévisible capable de manipuler les esprits et d'imposer sa volonté à quiconque. Avec ses pouvoirs et les immenses ressources que lui procure la Fondation, il s'est donné pour objectif d'étendre sa domination aux ultimes vestiges de l'Empire défunt.\nMais déjà une nouvelle légende prend forme : il existerait une Seconde Fondation, consacrée aux sciences mentales, œuvrant de façon occulte pour garantir l'accomplissement des desseins du légendaire Hari Seldon...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070360529"
+          "href" : "http://localhost:12345/api/v1/books/9782070360529"
         }
       }
     }, {
@@ -267,7 +267,7 @@
       "summary" : "Prévoyant l'effondrement prochain de l'Empire galactique, le psychohistorien Hari Seldon a jadis créé deux Fondations, l'une officielle, l'autre occulte, afin de préserver la civilisation d'une interminable période de chaos. Pourtant, cinq siècles après leur établissement, alors même que la Première Fondation n'a jamais été aussi puissante, un nouveau protagoniste semble entrer en jeu, œuvrant dans l'ombre à l'insu de tous.\nPeut-être tient-il entre ses mains le devenir de l'humanité tout entière...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070360635"
+          "href" : "http://localhost:12345/api/v1/books/9782070360635"
         }
       }
     }, {
@@ -278,7 +278,7 @@
       "summary" : "La Terre. Tout porte à croire que le légendaire berceau de l'humanité se trouve au cœur d'un vaste plan à l'échelle galactique, destiné à garantir en coulisse la pérennité de la civilisation : une synthèse parfaite entre le matérialisme de la Première Fondation et le mentalisme de la Seconde, mise en œuvre par une mystérieuse puissance. Mais comment trouver une planète que beaucoup croient mythique, et dont toute trace a inexplicablement disparu des archives galactiques ? Récompensé par le prix Hugo de la \"meilleure série de science-fiction de tous les temps Le cycle de Fondation est l'œuvre socle de la S-F moderne, celle que tous les amateurs du genre ont lue ou liront un jour.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070379668"
+          "href" : "http://localhost:12345/api/v1/books/9782070379668"
         }
       }
     }, {
@@ -289,7 +289,7 @@
       "summary" : "Première Loi : Un robot ne peut porter atteinte à un être humain ni, restant passif, laisser cet être humain exposé au danger. Deuxième Loi : Un robot doit obéir aux ordres donnés par les êtres humains, sauf si de tels ordres entrent en contradiction avec la Première Loi. Troisième Loi : Un robot doit protéger son existence dans la mesure où cette protection n'entre pas en contradiction avec la Première ou la Deuxième Loi.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290227268"
+          "href" : "http://localhost:12345/api/v1/books/9782290227268"
         }
       }
     }, {
@@ -300,7 +300,7 @@
       "summary" : "Comment risque de réagir un robot programmé pour un environnement lunaire dès lors qu'il se retrouve égaré sur Terre ? Un robot peut-il mentir à un procès pour préserver les intérêts de son utilisateur ? Le docteur Susan Calvin, robopsychologue, dialogue avec les androïdes pour faire la lumière sur ces étranges affaires. Et découvre davantage de défauts de programmation chez l'homme que chez ses fidèles créations...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290311257"
+          "href" : "http://localhost:12345/api/v1/books/9782290311257"
         }
       }
     }, {
@@ -311,7 +311,7 @@
       "summary" : "L'assassinat du docteur Sarton à Spacetown jette le trouble dans la communauté. Qui aurait intérêt a faire disparaître celui-là même qui milite pour le rapprochement entre Terriens et Spaciens ? Les Médiévalistes, qui ne voient pas d'un très bon œil la prolifération des robots ? Les Spaciens eux-mêmes, prêts à tout pour conserver leurs privilèges ? Le problème du détective Baley, toutefois, n'est pas seulement de retrouver un meurtrier, mais aussi et surtout d'y parvenir avant son collègue robot R Daneel. Car celui-ci est l'un de ces androïdes au cerveau électronique ultra-perfectionné, créés certes par l'homme, mais qui n'attendent peut-être que l'occasion de prendre sa place...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290319024"
+          "href" : "http://localhost:12345/api/v1/books/9782290319024"
         }
       }
     }, {
@@ -322,7 +322,7 @@
       "summary" : "C'est désormais sur la lointaine planète Solaria qu'Elijah Baley et R. Daneel Olivaw vont exercer leurs talents d'enquêteurs. Sur ce monde, les hommes n'acceptent plus de se rencontrer physiquement mais se \"visionnent\" par le truchement de projections télévisées. Or, un meurtre a été commis, un meurtre apparemment impossible puisque aucun Solarien n'aurait assez de courage pour s'approcher d'un de ses compatriotes.\nQui plus est, tout semble indiquer qu'un robot est impliqué. Absurde ! Les Lois de la robotique interdisent à ces êtres artificiels de causer le moindre tort aux hommes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290327944"
+          "href" : "http://localhost:12345/api/v1/books/9782290327944"
         }
       }
     }, {
@@ -333,7 +333,7 @@
       "summary" : "Quand Elijah Baley arrive sur Aurora, il pressent qu'il va au-devant de sa plus périlleuse mission. Il s'agit en effet pour lui de découvrir qui, pour la première fois dans la galaxie, s'est rendu coupable du meurtre de Jander Panell, le robot positronique le plus sophistiqué jamais créé, une créature atteignant un degré d'\" humanité \" très supérieur à tout ce que le Dr Susan Calvin aurait pu imaginer. Or le seul être qui possédait les compétences nécessaires pour commettre un tel crime n'est autre que son propre concepteur, le Dr Fastolfe ! Heureusement, Baley sera à nouveau assisté sur cette affaire de Daneel Olivaw, désormais l'unique robot humaniforme encore en activité...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290332757"
+          "href" : "http://localhost:12345/api/v1/books/9782290332757"
         }
       }
     }, {
@@ -344,7 +344,7 @@
       "summary" : "Plusieurs décennies se sont écoulées depuis les événements narrés dans \" les robots de l'aube \". Le docteur Amadiro voue une haine inextinguible à Glardia Gremionis pour avoir fait échouer ses plans de domination de la galaxie. Avec l'aide de Mandamus, un jeune et brillant scientifique, il ourdit à nouveau un plan d'éradication de l'humanité. Pour le contrer, Gladia est toujours assistée de Daneel, le robot humaniforme, et de Giskard, l'androïde télépathe, aux aptitudes nombreuses mais limitées par les restrictions qu'imposent les lois de la robotique. Et leurs choix seront d'autant plus ardus qu'une nouvelle loi, la loi zéro, va faire son apparition...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290311165"
+          "href" : "http://localhost:12345/api/v1/books/9782290311165"
         }
       }
     }, {
@@ -355,7 +355,7 @@
       "summary" : "Harry Potter est un garçon ordinaire. Mais le jour de ses onze ans, son existence bascule : un géant vient le chercher pour l'emmener dans une école de sorciers. Quel mystère entoure donc sa naissance et qui est l'effroyable V…, le mage dont personne n'ose prononcer le nom ? Voler à cheval sur des balais, jeter des sorts, combattre les Trolls : Harry Potter se révèle un sorcier vraiment doué. Quand il décide, avec ses amis, d'explorer les moindres recoins de son école, il va se trouver entraîné dans d'extraordinaires aventures.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624522"
+          "href" : "http://localhost:12345/api/v1/books/9782070624522"
         }
       }
     }, {
@@ -366,7 +366,7 @@
       "summary" : "Harry Potter fait une rentrée fracassante en voiture volante à l'école des sorciers. Cette deuxième année ne s'annonce pas de tout repos... surtout depuis qu'une étrange malédiction s'est abattue sur les élèves. Entre les cours de potion magique, les matches de Quidditch et les combats de mauvais sorts, Harry trouvera-t-il le temps de percer le mystère de la Chambre des Secrets ? Un livre magique pour sorciers confirmés.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624539"
+          "href" : "http://localhost:12345/api/v1/books/9782070624539"
         }
       }
     }, {
@@ -377,7 +377,7 @@
       "summary" : "\"Je jure solennellement que mes intentions sont mauvaises. \" Harry Potter",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624546"
+          "href" : "http://localhost:12345/api/v1/books/9782070624546"
         }
       }
     }, {
@@ -388,7 +388,7 @@
       "summary" : "Après un horrible été chez les Dursley, Harry Potter entre en quatrième année au collège de Poudlard. A quatorze ans, il voudrait simplement être un jeune sorcier comme les autres, retrouver ses amis Ron et Hermione, assister avec eux à la Coupe du Monde de Quidditch, apprendre de nouveaux sortilèges et essayer des potions inconnues. Une grande nouvelle l'attend à son arrivée : la tenue à Poudlard d'un tournoi de magie entre les plus célèbres écoles de sorcellerie.\nDéjà les spectaculaires délégations étrangères font leur entrée... Harry se réjouit. Trop vite. Il va se trouver plongé au coeur des événements les plus dramatiques qu'il ait jamais eu à affronter. Envoûtant, drôle, bouleversant, ce quatrième tome est le pilier central des aventures de Harry Potter.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624553"
+          "href" : "http://localhost:12345/api/v1/books/9782070624553"
         }
       }
     }, {
@@ -399,7 +399,7 @@
       "summary" : "A quinze ans, Harry s'apprête à entrer en cinquième année à Poudlard. Et s'il est heureux de retrouver le monde des sorciers, il n'a jamais été aussi anxieux. L'adolescence, la perspective des examens importants en fin d'année et ces étranges cauchemars.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624560"
+          "href" : "http://localhost:12345/api/v1/books/9782070624560"
         }
       }
     }, {
@@ -410,7 +410,7 @@
       "summary" : "\"C'est l'inconnu qui nous fait peur quand nous contemplons la mort ou l'obscurité, rien d'autre.\" Albus Dumbledore",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624904"
+          "href" : "http://localhost:12345/api/v1/books/9782070624904"
         }
       }
     }, {
@@ -421,7 +421,7 @@
       "summary" : "\"Harry est le meilleur espoir que nous ayons. Faites-lui confiance.\" Remus Lupin.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070624911"
+          "href" : "http://localhost:12345/api/v1/books/9782070624911"
         }
       }
     }, {
@@ -432,7 +432,7 @@
       "summary" : "De nouvelles illustrations enchanteresses pour le joyau de la bibliothèque de Poudlard ! Aventure, ruse, amour, magie, voici les cinq contes qui bercent l'enfance des sorciers. Traduit des runes par Hermione Granger, commenté par Albus Dumbledore, avec une introduction par J. K. Rowling, ce classique vous fera tour à tour rire ou frissonner.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070625192"
+          "href" : "http://localhost:12345/api/v1/books/9782070625192"
         }
       }
     }, {
@@ -443,7 +443,7 @@
       "summary" : "A Cuba, voilà quatre-vingt-quatre jours que le vieux Santiago rentre bredouille de la pêche, ses filets désespérément vides. La chance l'a déserté depuis longtemps. A l'aube du quatre-vingt-cinquième jour, son jeune ami Manolin lui fournit deux belles sardines fraîches pour appâter le poisson, et lui souhaite bonne chance en le regardant s'éloigner à bord de son petit bateau. Aujourd'hui, Santiago sent que la fortune lui revient.\nEt en effet, un poisson vient mordre à l'hameçon. C'est un marlin magnifique et gigantesque. Débute alors le plus âpre des duels. Combat de l'homme et de la nature, roman du courage et de l'espoir, Le vieil homme et la mer est un des plus grands livres de la littérature américaine.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782072762086"
+          "href" : "http://localhost:12345/api/v1/books/9782072762086"
         }
       }
     }, {
@@ -454,7 +454,7 @@
       "summary" : "Paris, années 1920. Jake Barnes, journaliste américain, retrouve la belle et frivole Lady Ashley, perdue dans une quête effrénée d'amants. Nous les suivons, s'abîmant dans l'alcool, des bars parisiens aux arènes espagnoles, en passant par les ruisseaux à truites des Pyrénées. Leurs compagnons, Robert Cohn, Michael Campbell, sont autant d'hommes à la dérive, marqués au fer rouge par la Première Guerre mondiale.\nDans un style limpide, d'une efficacité redoutable, Hemingway dépeint le Paris des écrivains de l'entre-deux- guerres et les fameuses fêtes de San Fermín. Ses héros, oscillant sans cesse entre mal de vivre et jouissance de l'instant présent, sont devenus les emblèmes de cette génération que Gertrude Stein qualifia de \"perdue\".",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782073004215"
+          "href" : "http://localhost:12345/api/v1/books/9782073004215"
         }
       }
     }, {
@@ -465,7 +465,7 @@
       "summary" : "\"Pas d'adieu, guapa, parce que nous ne sommes pas séparés. J'espère que tout ira bien dans les Gredos. Va maintenant. Va pour de bon. Non\", il continuait à parler tranquillement, sagement, tandis que Pilar entraînait la jeune fille. \"Ne te retourne pas. Mets ton pied dans l'étrier. Oui. Ton pied. Aide-la\", dit-il à Pilar. \"Soulève-la. Mets-la en selle\". Il tourna la tête, en sueur, et regarda vers le bas de la pente puis ramena son regard à l'endroit où la jeune fille était en selle avec Pilar auprès d'elle et Pablo juste derrière.\n\"Maintenant, va\", dit-il. \"Va\". Elle allait tourner la tête. \"Ne regarde pas en arrière\", dit Robert Jordan. \"Va\". Et Pablo frappa le cheval sur la croupe avec une entrave.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782072729935"
+          "href" : "http://localhost:12345/api/v1/books/9782072729935"
         }
       }
     }, {
@@ -476,7 +476,7 @@
       "summary" : "... ils commencèrent à prendre de l'altitude en direction de l'Est, semblait-il ; après quoi, cela s'obscurcit et ils se trouvèrent en pleine tempête, la pluie tellement drue qu'on eût cru voler à travers une cascade, et puis ils en sortirent et Compie tourna la tête et sourit en montrant quelque chose du doigt et là, devant eux, tout ce qu'il pouvait voir, vaste comme le monde, immense, haut et incroyablement blanc dans le soleil, c'était le sommet carré du Kilimandjaro.\nEt alors il comprit que c'était là qu'il allait.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070361519"
+          "href" : "http://localhost:12345/api/v1/books/9782070361519"
         }
       }
     }, {
@@ -487,7 +487,7 @@
       "summary" : "Rastignac est un jeune provincial qui cherche à s'insérer dans la société parisienne. Il lui manque les manières et l'argent. Pour parvenir, il côtoie les femmes du monde, mais reste attaché à son voisin de la pension Vauquer, le père Goriot, vieillard malheureux abandonné de ses filles. Vautrin, forçat évadé, Marsay, politicien ambitieux, et Rubempré, écrivain talentueux, sont animés du même désir de pouvoir.\nIls apprennent, chacun à leur manière, les complicités et les alliances indispensables dans une société gouvernée par les intérêts. Seules figures du désintéressement : le père Goriot, vaincu par son amour paternel, et Mme de Beauséant, abandonnée du Tout-Paris. La passion bout dans cette maison comme dans une cocotte-minute, les pages se tournent toutes seules; c'est que chaque palier de la pension Vauquer est devenu un étage de ce que Balzac vient de concevoir: La Comédie humaine.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070409341"
+          "href" : "http://localhost:12345/api/v1/books/9782070409341"
         }
       }
     }, {
@@ -498,7 +498,7 @@
       "summary" : "Un jeune aristocrate désargenté et désespéré, Raphaël de Valentin, reçoit d'un vieil antiquaire une peau d'onagre miraculeuse et maléfique : elle satisfait tous ses désirs, mais sa superficie, liée par un charme mystérieux à la durée de la vie de son possesseur, rétrécit à chaque souhait exaucé. Raphaël, qui rêvait de conquérir le monde, découvre ainsi, au prix de sa propre existence, que \"Vouloir nous brûle et Pouvoir nous détruit\" .\nSeul face à sa mort, dont il peut chaque jour calculer l'échéance, il délaisse la société des hommes, renonce à la jouissance du monde : en vain, même l'amour pur et partagé ne pourra le sauver. Dans le décor très réaliste des années 1830, La Peau de chagrin plonge le lecteur dans un univers proprement fantastique, un univers de l'étrange qui illustre l'une des théories philosophiques fondamentales de l'oeuvre balzacienne : l'énergie vitale.\nIntroduction et notes de Jacques Martineau.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782253006305"
+          "href" : "http://localhost:12345/api/v1/books/9782253006305"
         }
       }
     }, {
@@ -509,7 +509,7 @@
       "summary" : "Enfant trouvé fasciné par la carrière des armes, Hyacinthe dit Chabert s'est illustré aux premiers rangs de la Grande Armée. Laissé pour mort à Eylau, puis miraculeusement sauvé, il tentera quelques années plus tard de retrouver sa place dans une France bourgeoise qui veut oublier ses héros, auprès d'une femme qui lui doit tout, qui l'a dépouillé et qui le rejette. Nul destin, peut-être, n'éclaire mieux que le sien l'envers de la \" comédie humaine \", dans cette tragédie domestique doublée d'un drame social où le sublime côtoie constamment le sordide. \" Nous n'oublierons jamais l'entrée pitoyable de Chabert à l'étude Derville éclairée au gaz le matin, avec le déjeuner, réchauffé sur la cheminée, des clercs, des clercs rieurs, insolents et clabaudeurs, Chabert avec ses rides blanches, son vieux carrick, Chabert méprisé, aliéné de cette patrie et de cette femme qu'il continue à aimer, dénoncé de cette société où, bien qu'enfant trouvé, il s'était, si difficilement, fait un nom... Chabert a sa place dans toutes les mémoires, à côté du cousin Pons et du père Goriot, et sur le même rang. Le Colonel Chabert, admirable histoire de revenant. Paul MORAND.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782253098041"
+          "href" : "http://localhost:12345/api/v1/books/9782253098041"
         }
       }
     }, {
@@ -520,7 +520,7 @@
       "summary" : "1572.\nLa France des guerres de religion est devenue le champ clos des grands seigneurs et des prétendants au trône. A Paris, le jeune roi protestant de Navarre, le futur Henri IV, vient d'épouser Marguerite de Valois dite Margot ; mariage politique qui n'empêche pas les Guise et le roi Charles IX de fomenter les horreurs de la Saint-Barthélémy. Sur les pas du jeune comte de La Mole, dont s'éprend éperdument la belle Margot, et de son compagnon, le tonitruant Annibal de Coconnas, nous entrons dans ce labyrinthe d'intrigues, d'alliances, de trahisons. Les poignards luisent sous les pourpoints. René le Florentin fournit les poisons à l'implacable Catherine de Médicis. Le vieux Louvre avec ses fêtes brillantes, ses passages secrets, son peuple de soldats et de jolies femmes, est le théâtre où se déploient en mille péripéties les jeux de l'amour, de la politique, de la haine. Le père des Trois Mousquetaires nous en donne une passionnante chronique où sa pétulante bonne humeur survit aux plus sanglants épisodes.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782253099994"
+          "href" : "http://localhost:12345/api/v1/books/9782253099994"
         }
       }
     }, {
@@ -531,7 +531,7 @@
       "summary" : "1815. Louis XVIII rétabli sur le trône se heurte à une opposition dont l'Empereur, relégué à l'île d'Elbe, songe déjà à profiter. Dans Marseille livrée à la discorde civile, le moment est propice aux règlements de comptes politiques ou privés. C'est ainsi que le marin Edmond Dantès, à la veille de son mariage, se retrouve, sans savoir pourquoi, arrêté et conduit au château d'If... Paru en 1844-1846, Le Comte de Monte-Cristo connut un succès qui ne s'est pas démenti, ce qui en fait une des œuvres les plus populaires de la littérature mondiale.\nL'abbé Faria, l'évasion inouïe, le trésor grâce auquel les bons seront récompensés et les traîtres punis : le fabuleux destin d'Edmond Dantès possède la simplicité et la force des grands mythes. Conteur éblouissant, aussi à l'aise dans l'action que dans le dialogue, Dumas nous entraîne sans nous laisser reprendre souffle du cabinet de Louis XVIII à la Méditerranée des contrebandiers, des îles toscanes aux catacombes de Rome, puis aux salons parisiens où le mystérieux comte de Monte-Cristo se dispose à accomplir sa vengeance...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782253098058"
+          "href" : "http://localhost:12345/api/v1/books/9782253098058"
         }
       }
     }, {
@@ -542,7 +542,7 @@
       "summary" : "1838. Un seigneur étranger, le comte Monte-Cristo, intrigue le grand monde parisien par son faste extraordinaire, ses manières raffinées et fantasques, la jeune femme orientale qui vit dans son ombre. Qui - hormis peut-être la belle et mélancolique comtesse de Morcerf - pourrait reconnaître en lui le pauvre marin Dantès, arrêté à Marseille vingt-trois ans plus tôt ? A travers les péripéties d'une vengeance implacable, c'est le Paris de Balzac qui revit dans ce second volume.\nDandys, femmes du monde, personnages patibulaires ressurgis du bagne, se croisent autour d'inoubliables figures - le banquier politicien Danglars, le sévère procureur de Villefort, le hautain comte de Morcerf, pair de France. Romancier de l'histoire, l'auteur des Trois Mousquetaires et de La Reine Margot révèle dans ce chef-d'œuvre une autre facette de son génie : le roman de mœurs et de critique sociale, servi par un sens inégalé de l'action et du suspense.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782253098065"
+          "href" : "http://localhost:12345/api/v1/books/9782253098065"
         }
       }
     }, {
@@ -553,7 +553,7 @@
       "summary" : "Dans Les Trois Mousquetaires revit toute l'Histoire : le Moyen Age parce que c'est une épopée chevaleresque ; le XVIIème siècle dominé par Richelieu fondateur de la France moderne ; le romantisme parce que des héros exceptionnels, qui ont disparu d'une société contemporaine dépoétisée, se réfugient dans le roman. L'auteur y a mis tout son art : la surprise, la vitesse, l'humour, la couleur, le sens du mystère et de la grandeur. Le lecteur se sent un instant aventureux comme d'Artagnan, séducteur comme Aramis, hercule comme Porthos, profond comme Athos, poète comme Dumas.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070417681"
+          "href" : "http://localhost:12345/api/v1/books/9782070417681"
         }
       }
     } ],
@@ -562,7 +562,7 @@
       "name" : "J. K. Rowling",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/298b695e-306c-4b41-b2d1-95f295c88c37"
+          "href" : "http://localhost:12345/api/v1/authors/298b695e-306c-4b41-b2d1-95f295c88c37"
         }
       }
     }, {
@@ -570,7 +570,7 @@
       "name" : "Ernest Hemingway",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/88a5e171-9ac6-41d5-b6ac-aa9a93d12004"
+          "href" : "http://localhost:12345/api/v1/authors/88a5e171-9ac6-41d5-b6ac-aa9a93d12004"
         }
       }
     }, {
@@ -578,7 +578,7 @@
       "name" : "Jean-Jacques Rousseau",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"
+          "href" : "http://localhost:12345/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"
         }
       }
     }, {
@@ -586,7 +586,7 @@
       "name" : "Honoré de Balzac",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/4d5a8b1a-8d69-43c3-95e5-0c87f0883937"
+          "href" : "http://localhost:12345/api/v1/authors/4d5a8b1a-8d69-43c3-95e5-0c87f0883937"
         }
       }
     }, {
@@ -594,7 +594,7 @@
       "name" : "Isaac Asimov",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/ce4f9f7a-3d0d-47b0-acad-dd0103eaa1b5"
+          "href" : "http://localhost:12345/api/v1/authors/ce4f9f7a-3d0d-47b0-acad-dd0103eaa1b5"
         }
       }
     }, {
@@ -602,7 +602,7 @@
       "name" : "Alexandre Dumas",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/3d9c3009-32d0-49d0-a29e-d48ab05b8a61"
+          "href" : "http://localhost:12345/api/v1/authors/3d9c3009-32d0-49d0-a29e-d48ab05b8a61"
         }
       }
     }, {
@@ -610,7 +610,7 @@
       "name" : "John Ronald Reuel Tolkien",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/d8d94b64-603d-4fae-90dd-5296cde7fa2c"
+          "href" : "http://localhost:12345/api/v1/authors/d8d94b64-603d-4fae-90dd-5296cde7fa2c"
         }
       }
     }, {
@@ -618,23 +618,23 @@
       "name" : "George Raymond Richard Martin",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/c5f1361f-61b4-42c4-9cf1-d82e9a45317a"
+          "href" : "http://localhost:12345/api/v1/authors/c5f1361f-61b4-42c4-9cf1-d82e9a45317a"
         }
       }
     } ]
   },
   "_links" : {
     "first" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=50"
     },
     "self" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=50"
     },
     "next" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=1&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=1&size=50"
     },
     "last" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=1&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=1&size=50"
     }
   }
 }

--- a/website/src/test/resources/client/catalog/page-1-size-10.json
+++ b/website/src/test/resources/client/catalog/page-1-size-10.json
@@ -14,7 +14,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290208878"
+          "href" : "http://localhost:12345/api/v1/books/9782290208878"
         }
       }
     }, {
@@ -25,7 +25,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290215661"
+          "href" : "http://localhost:12345/api/v1/books/9782290215661"
         }
       }
     }, {
@@ -36,7 +36,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221686"
+          "href" : "http://localhost:12345/api/v1/books/9782290221686"
         }
       }
     }, {
@@ -47,7 +47,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221693"
+          "href" : "http://localhost:12345/api/v1/books/9782290221693"
         }
       }
     }, {
@@ -58,7 +58,7 @@
       "summary" : "Le royaume des Sept Couronnes est sur le point de connaître son plus terrible hiver : par-delà le Mur qui garde sa frontière nord, une armée de ténèbres se lève, menaçant de tout détruire sur son passage. Mais il en faut plus pour refroidir les ardeurs des rois, des reines, des chevaliers et des renégats qui se disputent le trône de fer. Tous les coups sont permis, et seuls les plus forts, ou les plus retors, s'en sortiront indemnes...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782290221709"
+          "href" : "http://localhost:12345/api/v1/books/9782290221709"
         }
       }
     }, {
@@ -69,7 +69,7 @@
       "summary" : "Winter is coming. Such is the stern motto of House Stark, the northernmost of the fiefdoms that owe allegiance to King Robert Baratheon in far-off King’s Landing. There Eddard Stark of Winterfell rules in Robert’s name. There his family dwells in peace and comfort: his proud wife, Catelyn; his sons Robb, Brandon, and Rickon; his daughters Sansa and Arya; and his bastard son, Jon Snow. Far to the north, behind the towering Wall, lie savage Wildings and worse—unnatural things relegated to myth during the centuries-long summer, but proving all too real and all too deadly in the turning of the season.\n\nYet a more immediate threat lurks to the south, where Jon Arryn, the Hand of the King, has died under mysterious circumstances. Now Robert is riding north to Winterfell, bringing his queen, the lovely but cold Cersei, his son, the cruel, vainglorious Prince Joffrey, and the queen’s brothers Jaime and Tyrion of the powerful and wealthy House Lannister—the first a swordsman without equal, the second a dwarf whose stunted stature belies a brilliant mind. All are heading for Winterfell and a fateful encounter that will change the course of kingdoms.\n\nMeanwhile, across the Narrow Sea, Prince Viserys, heir of the fallen House Targaryen, which once ruled all of Westeros, schemes to reclaim the throne with an army of barbarian Dothraki—whose loyalty he will purchase in the only coin left to him: his beautiful yet innocent sister, Daenerys.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553103540"
+          "href" : "http://localhost:12345/api/v1/books/9780553103540"
         }
       }
     }, {
@@ -80,7 +80,7 @@
       "summary" : "Time is out of joint. The summer of peace and plenty, ten years long, is drawing to a close, and the harsh, chill winter approaches like an angry beast. Two great leaders—Lord Eddard Stark and Robert Baratheon—who held sway over an age of enforced peace are dead . . . victims of royal treachery. Now, from the ancient citadel of Dragonstone to the forbidding shores of Winterfell, chaos reigns, as pretenders to the Iron Throne of the Seven Kingdoms prepare to stake their claims through tempest, turmoil, and war.\n\nAs a prophecy of doom cuts across the sky—a comet the color of blood and flame—six factions struggle for control of a divided land. Eddard’s son Robb has declared himself King in the North. In the south, Joffrey, the heir apparent, rules in name only, victim of the scheming courtiers who teem over King’s Landing. Robert’s two brothers each seek their own dominion, while a disfavored house turns once more to conquest. And a continent away, an exiled queen, the Mother of Dragons, risks everything to lead her precious brood across a hard hot desert to win back the crown that is rightfully hers.\n\nA Clash of Kings transports us into a magnificent, forgotten land of revelry and revenge, wizardry and warfare. It is a tale in which maidens cavort with madmen, brother plots against brother, and the dead rise to walk in the night. Here a princess masquerades as an orphan boy; a knight of the mind prepares a poison for a treacherous sorceress; and wild men descend from the Mountains of the Moon to ravage the countryside.\n\nAgainst a backdrop of incest and fratricide, alchemy and murder, the price of glory may be measured in blood. And the spoils of victory may just go to the men and women possessed of the coldest steel . . . and the coldest hearts. For when rulers clash, all of the land feels the tremors.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553108033"
+          "href" : "http://localhost:12345/api/v1/books/9780553108033"
         }
       }
     }, {
@@ -91,7 +91,7 @@
       "summary" : "Of the five contenders for power, one is dead, another in disfavor, and still the wars rage. Joffrey sits on the Iron Throne, the uneasy ruler of the Seven Kingdoms. His most bitter rival, Lord Stannis, stands defeated and disgraced, victim of the sorceress who holds him in her thrall. Young Robb still rules the North from the fortress of Riverrun. Meanwhile, making her way across a blood-drenched continent is the exiled queen, Daenerys, mistress of the only three dragons left in the world. As opposing forces maneuver for the final showdown, an army of barbaric wildlings arrives from the outermost limits of civilization, accompanied by a supernatural army of the living dead. As the future of the land hangs in the balance, no one will rest until the Seven Kingdoms have exploded in a veritable storm of swords...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553106633"
+          "href" : "http://localhost:12345/api/v1/books/9780553106633"
         }
       }
     }, {
@@ -102,7 +102,7 @@
       "summary" : "After centuries of bitter strife, the seven powers dividing the land have beaten one another into an uneasy truce. But it’s not long before the survivors, outlaws, renegades, and carrion eaters of the Seven Kingdoms gather. Now, as the human crows assemble over a banquet of ashes, daring new plots and dangerous new alliances are formed while surprising faces—some familiar, others only just appearing—emerge from an ominous twilight of past struggles and chaos to take up the challenges of the terrible times ahead. Nobles and commoners, soldiers and sorcerers, assassins and sages, are coming together to stake their fortunes . . . and their lives. For at a feast for crows, many are the guests—but only a few are the survivors.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553801507"
+          "href" : "http://localhost:12345/api/v1/books/9780553801507"
         }
       }
     }, {
@@ -113,7 +113,7 @@
       "summary" : "In the aftermath of a colossal battle, the future of the Seven Kingdoms hangs in the balance—beset by newly emerging threats from every direction. In the east, Daenerys Targaryen, the last scion of House Targaryen, rules with her three dragons as queen of a city built on dust and death. But Daenerys has thousands of enemies, and many have set out to find her. As they gather, one young man embarks upon his own quest for the queen, with an entirely different goal in mind.\n\nFleeing from Westeros with a price on his head, Tyrion Lannister, too, is making his way to Daenerys. But his newest allies in this quest are not the rag-tag band they seem, and at their heart lies one who could undo Daenerys’s claim to Westeros forever.\n\nMeanwhile, to the north lies the mammoth Wall of ice and stone—a structure only as strong as those guarding it. There, Jon Snow, 998th Lord Commander of the Night’s Watch, will face his greatest challenge. For he has powerful foes not only within the Watch but also beyond, in the land of the creatures of ice.\n\nFrom all corners, bitter conflicts reignite, intimate betrayals are perpetrated, and a grand cast of outlaws and priests, soldiers and skinchangers, nobles and slaves, will face seemingly insurmountable obstacles. Some will fail, others will grow in the strength of darkness. But in a time of rising restlessness, the tides of destiny and politics will lead inevitably to the greatest dance of all.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780553801477"
+          "href" : "http://localhost:12345/api/v1/books/9780553801477"
         }
       }
     } ],
@@ -122,26 +122,26 @@
       "name" : "George Raymond Richard Martin",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/c5f1361f-61b4-42c4-9cf1-d82e9a45317a"
+          "href" : "http://localhost:12345/api/v1/authors/c5f1361f-61b4-42c4-9cf1-d82e9a45317a"
         }
       }
     } ]
   },
   "_links" : {
     "first" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=10"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=10"
     },
     "prev" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=10"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=10"
     },
     "self" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=1&size=10"
+      "href" : "http://localhost:12345/api/v1/catalog?page=1&size=10"
     },
     "next" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=2&size=10"
+      "href" : "http://localhost:12345/api/v1/catalog?page=2&size=10"
     },
     "last" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=6&size=10"
+      "href" : "http://localhost:12345/api/v1/catalog?page=6&size=10"
     }
   }
 }

--- a/website/src/test/resources/client/catalog/page-1-size-50.json
+++ b/website/src/test/resources/client/catalog/page-1-size-50.json
@@ -14,7 +14,7 @@
       "summary" : "Dans la société moderne, beaucoup d'employés consacrent leur vie à des tâches inutiles et vides de sens. C'est ce que David Graeber appelle les \"bullshit jobs\" - ou \"jobs à la con\". L'auteur en cherche l'origine et en détaille les conséquences : dépression, anxiété, effondrement de l'estime de soi... Il en appelle à une révolte du salarié moderne ainsi qu'à une vaste réorganisation des valeurs, qui placerait le travail créatif et aidant au coeur de notre culture et ferait de la technologie un outil de libération plutôt que d'asservissement assouvissant enfin notre soif de sens et d'épanouissement.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9791020923769"
+          "href" : "http://localhost:12345/api/v1/books/9791020923769"
         }
       }
     }, {
@@ -25,7 +25,7 @@
       "summary" : "En remettant en perspective l'histoire de la dette depuis cinq mille ans, David Graeber renverse magistralement les théories admises. Il démontre que l'endettement a toujours été une construction sociale fondatrice du pouvoir. Aujourd'hui encore, les économistes entretiennent une vieille illusion : celle que l'opprobre est forcément à jeter sur les débiteurs, jamais sur les créanciers. Et si l'unique moyen d'éviter l'explosion sociale était justement...\nd'effacer les dettes ? Cet essai essentiel et foisonnant, par une des plus grandes figures de la réflexion politique contemporaine (David Graeber a directement inspiré le mouvement Occupy Wall Street), permet de mieux comprendre l'histoire du monde, la crise du crédit en cours et l'avenir de notre économie.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782330061258"
+          "href" : "http://localhost:12345/api/v1/books/9782330061258"
         }
       }
     }, {
@@ -36,7 +36,7 @@
       "summary" : "Voici l'édition Poche collector du grand livre de davdi Graeber et David Wengrow. Depuis des siècles, nous nous racontons sur les origines des sociétés humaines et des inégalités sociales une histoire très simple. Pendant l'essentiel de leur existence sur terre, les êtres humains auraient vécu au sein de petits clans de chasseurs-cueilleurs. Puis l'agriculture aurait fait son entrée, et avec elle la propriété privée.\nEnfin seraient nées les villes, marquant l'apparition non seulement de la civilisation, mais aussi des guerres, de la bureaucratie, du patriarcat et de l'esclavage. Ce récit pose un gros problème : il est faux.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9791020924636"
+          "href" : "http://localhost:12345/api/v1/books/9791020924636"
         }
       }
     }, {
@@ -47,7 +47,7 @@
       "summary" : "Vous voulez vous venger de l'avarice de votre maître ? Faites-lui croire qu'une troupe imaginaire de spadassins est à sa poursuite et que vous avez trouvé un moyen de le sauver. Prenez un sac. Mettez l'homme dans ce sac et prenez soin de bien le fermer. Promenez-le un peu sur votre dos à travers la ville. Profitez-en pour le rouer de temps à autre de coups de bâton. Mais prenez garde que votre victime ne découvre la supercherie...",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070449996"
+          "href" : "http://localhost:12345/api/v1/books/9782070449996"
         }
       }
     }, {
@@ -58,7 +58,7 @@
       "summary" : "Harpagon est l'une des plus grandes créations de Molière. Tout, dans cet homme, respire l'avarice et la décrépitude. Rongé par une maladie de corps, Harpagon l'est aussi par une maladie de l'âme. Ladre, il rogne sur la nourriture et les habits de ses domestiques, sur l'avoine de ses chevaux, sur l'entretien de son fils, obligé d'emprunter à taux usuraire pour vivre, et sur les cadeaux indispensables à sa fiancée. Usurier, il prête à des taux exorbitants, calcule, évalue tous les objets qui l'entourent. Dans cette atmosphère poussiéreuse et sordide, où fusent les mots féroces, le père usurier s'oppose au fils emprunteur. L'avarice détruit l'amour filial, l'amour paternel, l'amour quel qu'il soit. La cassette remplie d'or enterrée dans le jardin est l'âme, le coeur, le souffle même d'Harpagon. Les retrouvailles d'un homme et d'une cassette sont ici le seul hymne à l'amour.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070450022"
+          "href" : "http://localhost:12345/api/v1/books/9782070450022"
         }
       }
     }, {
@@ -69,7 +69,7 @@
       "summary" : "Après la première représentation du Tartuffe, le roi se voit obligé d'interdire la pièce et certains vont jusqu'à demander le bûcher pour son auteur. C'est que dans cette comédie, Molière dénonce la fausse dévotion, l'hypocrisie, l'imposture au service de l'ambition. Les amours de Marianne et de Valère sont menacées par le culte sans bornes que voue le bourgeois Orgon à un certain Tartuffe à qui il veut marier sa fille. Le héros, machiavélique et infâme, dont l'hypocrisie révolte les autres membres de la famille, entreprend de séduire Elmire, la femme de son hôte... Querelles, affrontements, portes qui claquent, supplications, l'un qui écoute aux portes, l'autre qui se cache sous la table, un huissier qui vient saisir les meubles, un Exempt qui fait intervenir la force publique : on n'a pas le temps de s'ennuyer dans la maison Orgon, le train y est infernal.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070449941"
+          "href" : "http://localhost:12345/api/v1/books/9782070449941"
         }
       }
     }, {
@@ -80,7 +80,7 @@
       "summary" : "Alceste est un \"mélancolique\" qui s'aveugle sur lui-même pour mieux condamner les autres. Placé dans une situation sociale comique, amoureux d'une coquette, il voit défiler tous les types humains qu'il réprouve. Molière a enfermé toute une époque dans un salon mondain, pour critiquer une société ambitieuse, avide et cynique. Il donne parfois raison à Alceste, lui qui refuse de se soumettre au mensonge et à l'artifice, lui qui affirme radicalement : \"J'ai tort, ou j'ai raison.\" Alceste n'est pas en accord avec son temps : il rejette les compromis, proteste contre la frivolité des salons et la fausseté des rapports humains. Le Misanthrope est ainsi la pièce la plus complexe de Molière, car la plus fidèle aux contradictions de l'homme et de la société.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070449934"
+          "href" : "http://localhost:12345/api/v1/books/9782070449934"
         }
       }
     }, {
@@ -91,7 +91,7 @@
       "summary" : "Il faut lire Le Cid dans sa première version, celle de 1637, qui explose comme un coup de tonnerre, avec la fougue de la jeunesse, le flamboiement du sang, les trompettes de la victoire. On s'aime, on se déchire, on libère sa patrie en quelques heures parmi les plus intenses de notre théâtre. Drame du conflit entre les sentiments passionnés et les dures contraintes du devoir moral et politique, la pièce offre une liberté de ton et une audace formelle que Corneille, pour se conformer aux codes d'une dramaturgie classique en train de se mettre en place, s'attachera par la suite à atténuer, mais dont le texte original, que cette édition restitue, conserve l'éclat.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070409181"
+          "href" : "http://localhost:12345/api/v1/books/9782070409181"
         }
       }
     }, {
@@ -102,7 +102,7 @@
       "summary" : "Juliette : Viens, nuit ! Viens, Roméo ! Viens, mon jour dans la nuit. Car sur les ailes de la nuit, tu vas reposer Plus blanc que sur le dos du corbeau la neige, Viens, douce nuit, amoureuse au front noir, Donne-moi Roméo ; et, quand je serai morte, Prends-le, fais-le se rompre en petites étoiles, Lui qui rendra si beau le visage du ciel Que l'univers sera comme fou de la nuit Et n'adorera plus l'aveuglant soleil (Acte III, scène II).",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070468485"
+          "href" : "http://localhost:12345/api/v1/books/9782070468485"
         }
       }
     }, {
@@ -113,7 +113,7 @@
       "summary" : "\"Voici l'heure sinistre de la nuit, L'heure des tombes qui s'ouvrent, celle où l'enfer Souffle au-dehors sa peste sur le monde. Maintenant je pourrais boire le sang chaud Et faire ce travail funeste que le jour Frissonnerait de voir. Mais, paix ! D'abord ma mère. Oh, n'oublie pas, mon coeur, qui elle est. Que jamais Une âme de Néron ne hante ta vigueur ! Sois féroce mais non dénaturé. Mes mots seuls la poignarderont ; c'est en cela Que mon âme et ma voix seront hypocrites ; Mon âme ! Aussi cinglantes soient mes paroles, Ne consens pas à les marquer du sceau des actes !\" (Acte III, scène II).",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070468508"
+          "href" : "http://localhost:12345/api/v1/books/9782070468508"
         }
       }
     }, {
@@ -124,7 +124,7 @@
       "summary" : "\"Sit down awhile, And let us once again assail your ears, That are so fortified against our story What we have two nights seen...\" The Tragedy of Hamlet, Prince of Denmark, often shortened to Hamlet, is a tragedy written by William Shakespeare at an uncertain date between 1599 and 1602. Set in the Kingdom of Denmark, the play dramatises the revenge Prince Hamlet is called to wreak upon his uncle, Claudius, by the ghost of Hamlet's father, King Hamlet. Claudius had murdered his own brother and seized the throne, also marrying his deceased brother's widow. Hamlet is Shakespeare's longest play, and is among the most powerful and influential tragedies in English literature, with a story capable of \"seemingly endless retelling and adaptation by others\". The play likely was one of Shakespeare's most popular works during his lifetime, and still ranks among his most performed.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9788490019481"
+          "href" : "http://localhost:12345/api/v1/books/9788490019481"
         }
       }
     }, {
@@ -135,7 +135,7 @@
       "summary" : "Dark and violent, Macbeth is a restless, haunting exploration of the human costs of violence and power. One of the most theatrically spectacular of Shakespeare's plays, Macbeth has endured as a psychologically and supernaturally sinister work. Emma Smith's introduction considers the historical and contemporary contexts of the play, from the influence of the Gunpowder Plot as an act of domestic terrorism, to the combination of banal domesticity and pure horror in the play's setting and events.\n\nThe New Oxford Shakespeare offers authoritative editions of Shakespeare's works with introductory materials designed to encourage new interpretations of the plays and poems. Using the text from the landmark The New Oxford Shakespeare Complete Works: Modern Critical Edition, these volumes offer readers the latest thinking on the authentic texts (collated from all surviving original versions of Shakespeare's work) alongside innovative introductions from leading scholars. The texts are accompanied by a comprehensive set of critical apparatus to give readers the best resources to help understand and enjoy Shakespeare's work.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9780192862426"
+          "href" : "http://localhost:12345/api/v1/books/9780192862426"
         }
       }
     }, {
@@ -146,7 +146,7 @@
       "summary" : "2084. Orwell est loin désormais. Le totalitarisme a pris les traits bonhommes de la social-démocratie. Souriez, vous êtes gérés ! Le citoyen ne s'opprime plus : il se fabrique. A la pâte à norme, au confort, au consensus. Copie qu'on forme, tout simplement. Au coeur de cette glu, un mouvement, une force de frappe, des fous : la Volte. Le Dehors est leur espace, subvertir leur seule arme. Emmenés par Capt, philosophe et stratège, le peintre Kamio et le fulgurant Slift que rien ne bloque ni ne borne, ils iront au bout de leur volution.\nEn perdant beaucoup. En gagnant tout. Premier roman, ici réécrit, La Zone du Dehors est un livre de combat contre nos sociétés de contrôle. Celle que nos gouvernements, nos multinationales, nos technologies et nos médias nous tissent aux fibres, tranquillement. Avec notre plus complice consentement. Peut-être est-il temps d'apprendre à boxer chaos debout contre le swing de la norme ?",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782072927522"
+          "href" : "http://localhost:12345/api/v1/books/9782072927522"
         }
       }
     }, {
@@ -157,7 +157,7 @@
       "summary" : "Un groupe d'élite, formé dès l'enfance à faire face, part des confins d'une terre féroce, saignée de rafales, pour aller chercher l'origine du vent. Ils sont vingt-trois, un bloc, un noeud de courage : la Horde. Ils sont pilier, ailier, traceur, aéromaître et géomaître, feuleuse et sourcière, troubadour et scribe. Ils traversent leur monde debout, à pied, en quête d'un Extrême-Amont qui fuit devant eux comme un horizon fou.\nExpérience de lecture unique, La Horde du Contrevent est un livre-univers qui fond d'un même feu l'aventure et la poésie des parcours, le combat nu et la quête d'un sens profond du vivant qui unirait le mouvement et le lien. Chaque mot résonne, claque, fuse : Alain Damasio joue de sa plume comme d'un pinceau, d'une caméra ou d'une arme... Chef-d'oeuvre porté par un bouche-à-oreille rare, le roman a été logiquement récompensé par le Grand Prix de l'Imaginaire.",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782072927515"
+          "href" : "http://localhost:12345/api/v1/books/9782072927515"
         }
       }
     }, {
@@ -168,7 +168,7 @@
       "summary" : "Ils sont là, parmi nous, jamais où tu regardes, à circuler dans les angles morts de la vision humaine. On les appelle les furtifs. Des fantômes ? Plutôt l'exact inverse : des êtres de chair et de sons, à la vitalité hors norme, qui métabolisent dans leur trajet pierres, déchets, animaux ou plantes pour alimenter leurs métamorphoses incessantes. Lorca Varèse, sociologue pour communes autogérées, et sa femme, Sahar, proferrante dans la rue pour les enfants que l'Education nationale, en faillite, a abandonnés, ont vu leur couple brisé par la disparition de leur fille unique de quatre ans, Tishka - volatilisée un matin, inexplicablement.\nSahar ne parvient pas à faire son deuil alors que Lorca, convaincu que sa fille est partie avec les furtifs, intègre une unité clandestine de l'armée chargée de chasser ces animaux extraordinaires. Peu à peu, ils apprendront à apprivoiser leur puissance de fuite et à renouer, grâce à eux, avec ce vivant que nos sociétés excommunient. Les furtifs nous plonge dans un futur proche où le libéralisme et la technologie n'ont jamais aussi bien maximisé nos servitudes volontaires - sous couvert de libération !",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782072847929"
+          "href" : "http://localhost:12345/api/v1/books/9782072847929"
         }
       }
     }, {
@@ -179,7 +179,7 @@
       "summary" : "\"Lorsque Gregor Samsa s'éveilla un matin au sortir de rêves agités, il se retrouva dans son lit changé en un énorme cancrelat. [... ] \"Que m'est-il arrivé ? \" pensa-t-il. Ce n'était pas un rêve. [... ] \"Et si je continuais un peu à dormir et oubliais toutes ces bêtises\", pensa-t-il, mais cela était tout à fait irréalisable, car il avait coutume de dormir sur le côté droit et il lui était impossible, dans son état actuel, de se mettre dans cette position.\nIl avait beau se jeter de toutes ses forces sur le côté droit, il rebondissait sans cesse sur le dos\".",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782070462872"
+          "href" : "http://localhost:12345/api/v1/books/9782070462872"
         }
       }
     }, {
@@ -190,7 +190,7 @@
       "summary" : "Joseph K. , cadre de banque, est arrêté chez lui, un beau matin, sans raison, le jour de son trentième anniversaire. Si on le laisse libre d'aller et venir, il ne cesse de se heurter à des obstacles absurdes, à des êtres étranges, à une réalité qui semble se dérober à mesure qu'il tente de percer le mystère de son \"arrestation\". Une justice invisible mais menaçante, qui ne définit jamais la faute qu'il a pu commettre, le cerne de toutes parts.\nLe Procès, que Kafka considérait comme inachevé, et qui parut en 1925, moins d'un an après sa mort, est un livre d'une originalité radicale, sans sources ni modèles, qui entraîne son personnage, tout comme les lecteurs, sur un terrain de plus en plus instable, à la manière des sables mouvants. Avec une notice de Régis Quatresous : \"Traduire, retraduire Le Procès. Pour saluer Alexandre Vialatte\".",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/books/9782073052872"
+          "href" : "http://localhost:12345/api/v1/books/9782073052872"
         }
       }
     } ],
@@ -199,7 +199,7 @@
       "name" : "Franz Kafka",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/406d7543-ad61-4807-bd28-d61022950463"
+          "href" : "http://localhost:12345/api/v1/authors/406d7543-ad61-4807-bd28-d61022950463"
         }
       }
     }, {
@@ -207,7 +207,7 @@
       "name" : "Pierre Corneille",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/00121904-81f3-44ec-b217-7c275dfa9b5b"
+          "href" : "http://localhost:12345/api/v1/authors/00121904-81f3-44ec-b217-7c275dfa9b5b"
         }
       }
     }, {
@@ -215,7 +215,7 @@
       "name" : "David Graeber",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/060d74f4-1d42-4087-b4ef-07dd00bb559c"
+          "href" : "http://localhost:12345/api/v1/authors/060d74f4-1d42-4087-b4ef-07dd00bb559c"
         }
       }
     }, {
@@ -223,7 +223,7 @@
       "name" : "David Wengrow",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/6e2051c4-8c1a-4611-9be1-0ff5755771d7"
+          "href" : "http://localhost:12345/api/v1/authors/6e2051c4-8c1a-4611-9be1-0ff5755771d7"
         }
       }
     }, {
@@ -231,7 +231,7 @@
       "name" : "Molière",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/9fdf9832-59d0-47e0-bfdf-1f7e1ce12b91"
+          "href" : "http://localhost:12345/api/v1/authors/9fdf9832-59d0-47e0-bfdf-1f7e1ce12b91"
         }
       }
     }, {
@@ -239,7 +239,7 @@
       "name" : "William Shakespeare",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/34100743-dcd0-45da-8142-8f4e650dd365"
+          "href" : "http://localhost:12345/api/v1/authors/34100743-dcd0-45da-8142-8f4e650dd365"
         }
       }
     }, {
@@ -247,23 +247,23 @@
       "name" : "Alain Damasio",
       "_links" : {
         "self" : {
-          "href" : "http://localhost:8080/api/v1/authors/87979468-9c9b-4883-b7c4-06c15c7bcf77"
+          "href" : "http://localhost:12345/api/v1/authors/87979468-9c9b-4883-b7c4-06c15c7bcf77"
         }
       }
     } ]
   },
   "_links" : {
     "first" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=50"
     },
     "prev" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=0&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=0&size=50"
     },
     "self" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=1&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=1&size=50"
     },
     "last" : {
-      "href" : "http://localhost:8080/api/v1/catalog?page=1&size=50"
+      "href" : "http://localhost:12345/api/v1/catalog?page=1&size=50"
     }
   }
 }

--- a/website/src/test/resources/client/catalog/page-6-size-10.json
+++ b/website/src/test/resources/client/catalog/page-6-size-10.json
@@ -17,7 +17,7 @@
         "summary": "\"Sit down awhile, And let us once again assail your ears, That are so fortified against our story What we have two nights seen...\" The Tragedy of Hamlet, Prince of Denmark, often shortened to Hamlet, is a tragedy written by William Shakespeare at an uncertain date between 1599 and 1602. Set in the Kingdom of Denmark, the play dramatises the revenge Prince Hamlet is called to wreak upon his uncle, Claudius, by the ghost of Hamlet's father, King Hamlet. Claudius had murdered his own brother and seized the throne, also marrying his deceased brother's widow. Hamlet is Shakespeare's longest play, and is among the most powerful and influential tragedies in English literature, with a story capable of \"seemingly endless retelling and adaptation by others\". The play likely was one of Shakespeare's most popular works during his lifetime, and still ranks among his most performed.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9788490019481"
+            "href": "http://localhost:12345/api/v1/books/9788490019481"
           }
         }
       },
@@ -31,7 +31,7 @@
         "summary": "Dark and violent, Macbeth is a restless, haunting exploration of the human costs of violence and power. One of the most theatrically spectacular of Shakespeare's plays, Macbeth has endured as a psychologically and supernaturally sinister work. Emma Smith's introduction considers the historical and contemporary contexts of the play, from the influence of the Gunpowder Plot as an act of domestic terrorism, to the combination of banal domesticity and pure horror in the play's setting and events.\n\nThe New Oxford Shakespeare offers authoritative editions of Shakespeare's works with introductory materials designed to encourage new interpretations of the plays and poems. Using the text from the landmark The New Oxford Shakespeare Complete Works: Modern Critical Edition, these volumes offer readers the latest thinking on the authentic texts (collated from all surviving original versions of Shakespeare's work) alongside innovative introductions from leading scholars. The texts are accompanied by a comprehensive set of critical apparatus to give readers the best resources to help understand and enjoy Shakespeare's work.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9780192862426"
+            "href": "http://localhost:12345/api/v1/books/9780192862426"
           }
         }
       },
@@ -45,7 +45,7 @@
         "summary": "2084. Orwell est loin désormais. Le totalitarisme a pris les traits bonhommes de la social-démocratie. Souriez, vous êtes gérés ! Le citoyen ne s'opprime plus : il se fabrique. A la pâte à norme, au confort, au consensus. Copie qu'on forme, tout simplement. Au coeur de cette glu, un mouvement, une force de frappe, des fous : la Volte. Le Dehors est leur espace, subvertir leur seule arme. Emmenés par Capt, philosophe et stratège, le peintre Kamio et le fulgurant Slift que rien ne bloque ni ne borne, ils iront au bout de leur volution.\nEn perdant beaucoup. En gagnant tout. Premier roman, ici réécrit, La Zone du Dehors est un livre de combat contre nos sociétés de contrôle. Celle que nos gouvernements, nos multinationales, nos technologies et nos médias nous tissent aux fibres, tranquillement. Avec notre plus complice consentement. Peut-être est-il temps d'apprendre à boxer chaos debout contre le swing de la norme ?",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782072927522"
+            "href": "http://localhost:12345/api/v1/books/9782072927522"
           }
         }
       },
@@ -59,7 +59,7 @@
         "summary": "Un groupe d'élite, formé dès l'enfance à faire face, part des confins d'une terre féroce, saignée de rafales, pour aller chercher l'origine du vent. Ils sont vingt-trois, un bloc, un noeud de courage : la Horde. Ils sont pilier, ailier, traceur, aéromaître et géomaître, feuleuse et sourcière, troubadour et scribe. Ils traversent leur monde debout, à pied, en quête d'un Extrême-Amont qui fuit devant eux comme un horizon fou.\nExpérience de lecture unique, La Horde du Contrevent est un livre-univers qui fond d'un même feu l'aventure et la poésie des parcours, le combat nu et la quête d'un sens profond du vivant qui unirait le mouvement et le lien. Chaque mot résonne, claque, fuse : Alain Damasio joue de sa plume comme d'un pinceau, d'une caméra ou d'une arme... Chef-d'oeuvre porté par un bouche-à-oreille rare, le roman a été logiquement récompensé par le Grand Prix de l'Imaginaire.",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782072927515"
+            "href": "http://localhost:12345/api/v1/books/9782072927515"
           }
         }
       },
@@ -73,7 +73,7 @@
         "summary": "Ils sont là, parmi nous, jamais où tu regardes, à circuler dans les angles morts de la vision humaine. On les appelle les furtifs. Des fantômes ? Plutôt l'exact inverse : des êtres de chair et de sons, à la vitalité hors norme, qui métabolisent dans leur trajet pierres, déchets, animaux ou plantes pour alimenter leurs métamorphoses incessantes. Lorca Varèse, sociologue pour communes autogérées, et sa femme, Sahar, proferrante dans la rue pour les enfants que l'Education nationale, en faillite, a abandonnés, ont vu leur couple brisé par la disparition de leur fille unique de quatre ans, Tishka - volatilisée un matin, inexplicablement.\nSahar ne parvient pas à faire son deuil alors que Lorca, convaincu que sa fille est partie avec les furtifs, intègre une unité clandestine de l'armée chargée de chasser ces animaux extraordinaires. Peu à peu, ils apprendront à apprivoiser leur puissance de fuite et à renouer, grâce à eux, avec ce vivant que nos sociétés excommunient. Les furtifs nous plonge dans un futur proche où le libéralisme et la technologie n'ont jamais aussi bien maximisé nos servitudes volontaires - sous couvert de libération !",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782072847929"
+            "href": "http://localhost:12345/api/v1/books/9782072847929"
           }
         }
       },
@@ -87,7 +87,7 @@
         "summary": "\"Lorsque Gregor Samsa s'éveilla un matin au sortir de rêves agités, il se retrouva dans son lit changé en un énorme cancrelat. [... ] \"Que m'est-il arrivé ? \" pensa-t-il. Ce n'était pas un rêve. [... ] \"Et si je continuais un peu à dormir et oubliais toutes ces bêtises\", pensa-t-il, mais cela était tout à fait irréalisable, car il avait coutume de dormir sur le côté droit et il lui était impossible, dans son état actuel, de se mettre dans cette position.\nIl avait beau se jeter de toutes ses forces sur le côté droit, il rebondissait sans cesse sur le dos\".",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782070462872"
+            "href": "http://localhost:12345/api/v1/books/9782070462872"
           }
         }
       },
@@ -101,7 +101,7 @@
         "summary": "Joseph K. , cadre de banque, est arrêté chez lui, un beau matin, sans raison, le jour de son trentième anniversaire. Si on le laisse libre d'aller et venir, il ne cesse de se heurter à des obstacles absurdes, à des êtres étranges, à une réalité qui semble se dérober à mesure qu'il tente de percer le mystère de son \"arrestation\". Une justice invisible mais menaçante, qui ne définit jamais la faute qu'il a pu commettre, le cerne de toutes parts.\nLe Procès, que Kafka considérait comme inachevé, et qui parut en 1925, moins d'un an après sa mort, est un livre d'une originalité radicale, sans sources ni modèles, qui entraîne son personnage, tout comme les lecteurs, sur un terrain de plus en plus instable, à la manière des sables mouvants. Avec une notice de Régis Quatresous : \"Traduire, retraduire Le Procès. Pour saluer Alexandre Vialatte\".",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/books/9782073052872"
+            "href": "http://localhost:12345/api/v1/books/9782073052872"
           }
         }
       }
@@ -112,7 +112,7 @@
         "name": "Franz Kafka",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/authors/406d7543-ad61-4807-bd28-d61022950463"
+            "href": "http://localhost:12345/api/v1/authors/406d7543-ad61-4807-bd28-d61022950463"
           }
         }
       },
@@ -121,7 +121,7 @@
         "name": "William Shakespeare",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/authors/34100743-dcd0-45da-8142-8f4e650dd365"
+            "href": "http://localhost:12345/api/v1/authors/34100743-dcd0-45da-8142-8f4e650dd365"
           }
         }
       },
@@ -130,7 +130,7 @@
         "name": "Alain Damasio",
         "_links": {
           "self": {
-            "href": "http://localhost:8080/api/v1/authors/87979468-9c9b-4883-b7c4-06c15c7bcf77"
+            "href": "http://localhost:12345/api/v1/authors/87979468-9c9b-4883-b7c4-06c15c7bcf77"
           }
         }
       }
@@ -138,16 +138,16 @@
   },
   "_links": {
     "first": {
-      "href": "http://localhost:8080/api/v1/catalog?page=0&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=0&size=10"
     },
     "prev": {
-      "href": "http://localhost:8080/api/v1/catalog?page=5&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=5&size=10"
     },
     "self": {
-      "href": "http://localhost:8080/api/v1/catalog?page=6&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=6&size=10"
     },
     "last": {
-      "href": "http://localhost:8080/api/v1/catalog?page=6&size=10"
+      "href": "http://localhost:12345/api/v1/catalog?page=6&size=10"
     }
   }
 }


### PR DESCRIPTION
The link is passed as a query parameter in the website URL, and the corresponding url is retrieved from the previously browsed page's links. This previously browsed page is stored in a session scope bean injected in the controller. In case of server crash or restart, the navigation session is lost and the controller redirects to the default catalog page.