### PR TITLE
feat: Add books in the catalog endpoint

### DIFF
--- a/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/CatalogStepDefinitions.java
+++ b/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/CatalogStepDefinitions.java
@@ -17,7 +17,7 @@ public class CatalogStepDefinitions {
 
     private ValidatableResponse response;
 
-    @When("he browses the catalog to page {int} showing {int} editions")
+    @When("he browses the catalog to page {int} showing {int} books")
     public void browseCatalogToPage(int page, int pageSize) {
         response = given().params(
                         "page", page,
@@ -38,16 +38,16 @@ public class CatalogStepDefinitions {
         response = when().get(link).then();
     }
 
-    @Then("the catalog returns page {int} containing {int} editions over {int} requested")
+    @Then("the catalog returns page {int} containing {int} books over {int} requested")
     public void catalogReturnedPage(int page, int pageElements, int pageSize) {
         response.statusCode(206)
                 .contentType("application/json")
                 .body("page.number", describedAs(STR."Page number = \{page}", equalTo(page)))
                 .body("page.size", describedAs(STR."Page size = \{pageSize}", equalTo(pageSize)))
-                .body("_embedded.editions", describedAs(STR."Embedded editions size = \{pageElements}", hasSize(pageElements)));
+                .body("_embedded.books", describedAs(STR."Embedded books size = \{pageElements}", hasSize(pageElements)));
     }
 
-    @Then("the catalog contains {int} editions in a total of {int} pages")
+    @Then("the catalog contains {int} books in a total of {int} pages")
     public void catalogReturnedElements(int totalElements, int totalPages) {
         response.statusCode(206)
                 .contentType("application/json")
@@ -66,16 +66,16 @@ public class CatalogStepDefinitions {
         linkNames.forEach(link -> response.body("_links", describedAs(STR."Link \{link} must be present in catalog links", hasKey(link))));
     }
 
-    @Then("the page {int} contains editions corresponding to the expected {isbns}")
-    public void catalogPageWithIsbns(int page, List<String> isbns) {
-        for (int index = 0; index < isbns.size(); index++) {
-            var isbn = isbns.get(index);
-            response.body("_embedded.editions[%d].isbn", withArgs(index),
-                    describedAs(STR."Edition with index \{index} within page \{page} must have ISBN = \{isbn}", equalTo(isbn)));
+    @Then("the page {int} contains books corresponding to the expected {ids}")
+    public void catalogPageWithIds(int page, List<String> ids) {
+        for (int index = 0; index < ids.size(); index++) {
+            var id = ids.get(index);
+            response.body("_embedded.books[%d].id", withArgs(index),
+                    describedAs(STR."Book with index \{index} within page \{page} must have id starting with \{id}", startsWith(id)));
         }
     }
 
-    @Then("the page {int} contains {authorNames} corresponding to the editions")
+    @Then("the page {int} contains {authorNames} corresponding to the books")
     public void catalogPageWithAuthors(int page, List<String> authorNames) {
         assertResponseEmbedsAuthors(response, authorNames, name -> STR."Catalog page \{page} must contain author named \{name}");
     }

--- a/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/Parameters.java
+++ b/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/Parameters.java
@@ -15,6 +15,11 @@ public class Parameters {
     }
 
     @ParameterType(".*")
+    public List<String> ids(String source) {
+        return List.of(source.split(", "));
+    }
+
+    @ParameterType(".*")
     public List<String> isbns(String source) {
         return List.of(source.split(", "));
     }

--- a/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/assertions/EmbeddedAuthorsAssertions.java
+++ b/catalog/src/acceptance/java/org/adhuc/library/catalog/acceptance/assertions/EmbeddedAuthorsAssertions.java
@@ -6,14 +6,14 @@ import java.util.List;
 import java.util.function.Function;
 
 import static io.restassured.RestAssured.withArgs;
-import static org.hamcrest.Matchers.describedAs;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 public class EmbeddedAuthorsAssertions {
 
     public static void assertResponseEmbedsAuthors(ValidatableResponse response,
                                                    List<String> authorNames,
                                                    Function<String, String> assertionDescription) {
+        response.body("_embedded.authors", hasSize(authorNames.size()));
         authorNames.forEach(name ->
                 response.body("_embedded.authors.find { it.name == '%s' }", withArgs(name),
                         describedAs(assertionDescription.apply(name), notNullValue()))

--- a/catalog/src/acceptance/resources/features/browsing-catalog.feature
+++ b/catalog/src/acceptance/resources/features/browsing-catalog.feature
@@ -5,9 +5,9 @@ Feature: Browse the catalog
 
 		Scenario Outline: Retrieve the catalog pages
 			Given Georges is a library member
-			When he browses the catalog to page <page> showing <pageSize> editions
-			Then the catalog returns page <page> containing <pageElements> editions over <pageSize> requested
-			And the catalog contains <totalElements> editions in a total of <totalPages> pages
+			When he browses the catalog to page <page> showing <pageSize> books
+			Then the catalog returns page <page> containing <pageElements> books over <pageSize> requested
+			And the catalog contains <totalElements> books in a total of <totalPages> pages
 			Examples:
 				| page | pageSize | pageElements | totalElements | totalPages |
 				| 0    | 10       | 10           | 67            | 7          |
@@ -21,7 +21,7 @@ Feature: Browse the catalog
 		Scenario: Retrieve the catalog by default will get the first page with 50 elements
 			Given Georges is a library member
 			When he browses the catalog for the first time
-			Then the catalog returns page 0 containing 50 editions over 50 requested
+			Then the catalog returns page 0 containing 50 books over 50 requested
 
 	Rule: The catalog provides links to navigate through pagination:
 	- first: navigates to the first page
@@ -33,7 +33,7 @@ Feature: Browse the catalog
 
 		Scenario Outline:
 			Given Georges is a library member
-			When he browses the catalog to page <page> showing <pageSize> editions
+			When he browses the catalog to page <page> showing <pageSize> books
 			Then the catalog returns page <page> with available <navigation> links
 			Examples:
 				| page | pageSize | navigation                    |
@@ -47,9 +47,9 @@ Feature: Browse the catalog
 
 		Scenario Outline:
 			Given Georges is a library member
-			When he browses the catalog to page <page> showing <pageSize> editions
+			When he browses the catalog to page <page> showing <pageSize> books
 			And he navigates through the catalog with <navigation> link
-			Then the catalog returns page <newPage> containing <pageElements> editions over <pageSize> requested
+			Then the catalog returns page <newPage> containing <pageElements> books over <pageSize> requested
 			Examples:
 				| page | pageSize | navigation | newPage | pageElements |
 				| 0    | 10       | self       | 0       | 10           |
@@ -65,34 +65,34 @@ Feature: Browse the catalog
 				| 1    | 25       | prev       | 0       | 25           |
 				| 1    | 25       | next       | 2       | 17           |
 
-	Rule: The catalog provides each edition only one time within all pages
+	Rule: The catalog provides each books only one time within all pages
 
 		Scenario Outline:
 			Given Georges is a library member
-			When he browses the catalog to page <page> showing <pageSize> editions
-			Then the page <page> contains editions corresponding to the expected <isbns>
+			When he browses the catalog to page <page> showing <pageSize> books
+			Then the page <page> contains books corresponding to the expected <ids>
 			Examples:
-				| page | pageSize | isbns                                                                                                                                                |
-				| 0    | 10       | 9782081275232, 9782081275256, 9782081206922, 9782070399697, 9782081409842, 9782267046885, 9782267046892, 9782267046908, 9782266339667, 9782267044706 |
-				| 1    | 10       | 9782290208878, 9782290215661, 9782290221686, 9782290221693, 9782290221709, 9780553103540, 9780553108033, 9780553106633, 9780553801507, 9780553801477 |
-				| 2    | 10       | 9782070360536, 9782070360550, 9782070360529, 9782070360635, 9782070379668, 9782290227268, 9782290311257, 9782290319024, 9782290327944, 9782290332757 |
-				| 3    | 10       | 9782290311165, 9782070624522, 9782070624539, 9782070624546, 9782070624553, 9782070624560, 9782070624904, 9782070624911, 9782070625192, 9782072762086 |
-				| 4    | 10       | 9782073004215, 9782072729935, 9782070361519, 9782070409341, 9782253006305, 9782253098041, 9782253099994, 9782253098058, 9782253098065, 9782070417681 |
-				| 5    | 10       | 9791020923769, 9782330061258, 9791020924636, 9782070449996, 9782070450022, 9782070449941, 9782070449934, 9782070409181, 9782070468485, 9782070468508 |
-				| 6    | 10       | 9788490019481, 9780192862426, 9782072927522, 9782072927515, 9782072847929, 9782070462872, 9782073052872                                              |
+				| page | pageSize | ids                                                                                                |
+				| 0    | 10       | b6608a30, 74d88208, 94856bb6, 5a47a523, 4082a49e, c2dd1a78, 434fcb17, e8cbad19, e3957d3f, aafe7eb6 |
+				| 1    | 10       | 3b35e0ae, 2e601f14, 0a881b54, 907716df, 2869e847, e6854cf5, 273c8353, b7392578, 699b97dc, 65e5d471 |
+				| 2    | 10       | 80211681, 1881ab54, 41e9e43c, c18a14f2, fddf98d1, 5df9d315, cfa4ce14, 14185458, 6cef0208, 3df147a8 |
+				| 3    | 10       | a49d474e, 2ad81543, 9157773d, a8e23d8c, 105be558, f1e5c7c6, ac9526cd, d56a66a3, f1dbbe65, e2b0c423 |
+				| 4    | 10       | 874c578c, ae5a92fc, ade812f1, a093173a, eb99a4d5, 481bb3f4, df2c8d87, 7b2eb526, d035a894, ac702d27 |
+				| 5    | 10       | 89c1cce8, 809d3368, 9eab131c, 3c25ef66, c12f91f3, 1517f41e, 858eba66, 824ea2db, 97611133, e568c46d |
+				| 6    | 10       | f4d4542f, fbd4d363, ea6cc5dc, bdd603ba, e1030011, 0c959d74, ace93305                               |
 
-	Rule: The catalog provides author for each edition within a page
+	Rule: The catalog provides author for each book within a page
 
 		Scenario Outline:
 			Given Georges is a library member
-			When he browses the catalog to page <page> showing <pageSize> editions
-			Then the page <page> contains <authors> corresponding to the editions
+			When he browses the catalog to page <page> showing <pageSize> books
+			Then the page <page> contains <authors> corresponding to the books
 			Examples:
-				| page | pageSize | authors                                                                      |
-				| 0    | 10       | Jean-Jacques Rousseau, John Ronald Reuel Tolkien                             |
-				| 1    | 10       | George Raymond Richard Martin                                                |
-				| 2    | 10       | Isaac Asimov                                                                 |
-				| 3    | 10       | Isaac Asimov, J. K. Rowling, Ernest Hemingway                                |
-				| 4    | 10       | Ernest Hemingway, Honoré de Balzac, Alexandre Dumas                          |
-				| 5    | 10       | David Graeber, David Wengrow, Molière, Pierre Corneille, William Shakespeare |
-				| 6    | 10       | William Shakespeare, Alain Damasio, Franz Kafka                              |
+				| page | pageSize | authors                                                                    |
+				| 0    | 10       | Jean-Jacques Rousseau, John Ronald Reuel Tolkien                           |
+				| 1    | 10       | George Raymond Richard Martin, Isaac Asimov                                |
+				| 2    | 10       | Isaac Asimov, J. K. Rowling                                                |
+				| 3    | 10       | J. K. Rowling, Ernest Hemingway, Honoré de Balzac                          |
+				| 4    | 10       | Honoré de Balzac, Alexandre Dumas, David Graeber, David Wengrow, Molière   |
+				| 5    | 10       | Molière, Pierre Corneille, William Shakespeare, Alain Damasio, Franz Kafka |
+				| 6    | 10       | Daniel Pennac, George Orwell                                               |

--- a/catalog/src/data/catalog-authors.json
+++ b/catalog/src/data/catalog-authors.json
@@ -84,5 +84,16 @@
     "name": "Franz Kafka",
     "dateOfBirth": "1883-07-03",
     "dateOfDeath": "1924-06-03"
+  },
+  {
+    "id": "5033571c-baeb-459b-9547-35ca77618048",
+    "name": "Daniel Pennac",
+    "dateOfBirth": "1944-12-01"
+  },
+  {
+    "id": "69831d56-5843-409b-9101-fc66bea8fc2f",
+    "name": "George Orwell",
+    "dateOfBirth": "1903-06-25",
+    "dateOfDeath": "1950-01-21"
   }
 ]

--- a/catalog/src/data/catalog-books.json
+++ b/catalog/src/data/catalog-books.json
@@ -1679,5 +1679,178 @@
         ]
       }
     ]
+  },
+  {
+    "id": "f4d4542f-9fd3-44e8-8052-5ff63bf1b53c",
+    "authors": [
+      "5033571c-baeb-459b-9547-35ca77618048"
+    ],
+    "originalLanguage": "fr",
+    "details": [
+      {
+        "language": "fr",
+        "title": "Cabot-Caboche",
+        "description": "Cabot-Caboche est un roman pour la jeunesse de Daniel Pennac, paru en 1982.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/Cabot-Caboche"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "fbd4d363-102c-419d-a6dc-67180a4ccb5d",
+    "authors": [
+      "5033571c-baeb-459b-9547-35ca77618048"
+    ],
+    "originalLanguage": "fr",
+    "details": [
+      {
+        "language": "fr",
+        "title": "Au bonheur des ogres",
+        "description": "Au bonheur des ogres est un roman policier de Daniel Pennac paru en 1985. Il constitue le premier de la Saga Malaussène. Le titre est inspiré du roman Au Bonheur des Dames d'Émile Zola, dans lequel le récit entraîne le lecteur dans le monde des grands magasins. Le livre est traduit dans plus d'une dizaine de langues.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/Au_bonheur_des_ogres"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ea6cc5dc-2f1a-4baa-88b5-6c1f5cb34965",
+    "authors": [
+      "5033571c-baeb-459b-9547-35ca77618048"
+    ],
+    "originalLanguage": "fr",
+    "details": [
+      {
+        "language": "fr",
+        "title": "La Fée Carabine",
+        "description": "La Fée Carabine est un roman policier de Daniel Pennac paru en 1987 et édité par Gallimard dans la collection Folio. Cet ouvrage est le deuxième titre de la Saga Malaussène. Le roman a été écrit à Cossogno, un petit village d'Italie du Nord.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/La_Fée_Carabine"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "bdd603ba-43f3-4253-9b30-8e0c864a03f7",
+    "authors": [
+      "5033571c-baeb-459b-9547-35ca77618048"
+    ],
+    "originalLanguage": "fr",
+    "details": [
+      {
+        "language": "fr",
+        "title": "Comme un roman",
+        "description": " Comme un roman est un essai de Daniel Pennac paru en 1992 aux éditions Gallimard.\n\nCet essai se veut à la fois un hymne et une désacralisation de la lecture, ainsi qu'une invitation à réfléchir à la manière pédagogique de l'appréhender. Il constitue ainsi une critique des techniques, exigences et recommandations de l'éducation nationale.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/Comme_un_roman"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "e1030011-98d0-48b6-bc68-3176c4ec0dd9",
+    "authors": [
+      "69831d56-5843-409b-9101-fc66bea8fc2f"
+    ],
+    "originalLanguage": "en",
+    "details": [
+      {
+        "language": "en",
+        "title": "Homage to Catalonia",
+        "description": "Homage to Catalonia is a 1938 memoir by English writer George Orwell, in which he accounts his personal experiences and observations while fighting in the Spanish Civil War.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://en.wikipedia.org/wiki/Homage_to_Catalonia"
+          }
+        ]
+      },
+      {
+        "language": "fr",
+        "title": "Hommage à la Catalogne",
+        "description": "Hommage à la Catalogne (titre original : Homage to Catalonia) est un ouvrage de l’écrivain britannique George Orwell, qui traite de la guerre civile espagnole, paru en 1938. L’édition française, dans une traduction d'Yvonne Davet, est publiée pour la première fois en 1955 aux éditions Gallimard sous le titre La Catalogne libre.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/Hommage_à_la_Catalogne"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "0c959d74-591c-489c-a7ca-4d7acb0ceba8",
+    "authors": [
+      "69831d56-5843-409b-9101-fc66bea8fc2f"
+    ],
+    "originalLanguage": "en",
+    "details": [
+      {
+        "language": "en",
+        "title": "Animal Farm",
+        "description": "Animal Farm is a satirical allegorical novella, in the form of a beast fable, by George Orwell, first published in England on 17 August 1945. It tells the story of a group of anthropomorphic farm animals who rebel against their human farmer, hoping to create a society where the animals can be equal, free, and happy. Ultimately, the rebellion is betrayed, and under the dictatorship of a pig named Napoleon, the farm ends up in a far worse state than before.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://en.wikipedia.org/wiki/Animal_Farm"
+          }
+        ]
+      },
+      {
+        "language": "fr",
+        "title": "La Ferme des animaux",
+        "description": "La Ferme des animaux (titre original : Animal Farm. A Fairy Story) est un roman court de George Orwell, publié en 1945. Découpé en dix chapitres, il décrit une ferme dans laquelle les animaux se révoltent contre leur maître, prennent le pouvoir, chassent les hommes et vivent en autarcie.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/La_Ferme_des_animaux"
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "id": "ace93305-508e-490c-ad93-f69d4beeb7a4",
+    "authors": [
+      "69831d56-5843-409b-9101-fc66bea8fc2f"
+    ],
+    "originalLanguage": "en",
+    "details": [
+      {
+        "language": "en",
+        "title": "Nineteen Eighty-Four",
+        "description": "Nineteen Eighty-Four (also published as 1984) is a dystopian novel and cautionary tale by English writer George Orwell. It was published on 8 June 1949 by Secker & Warburg as Orwell's ninth and final completed book. Thematically, it centres on the consequences of totalitarianism, mass surveillance, and repressive regimentation of people and behaviours within society. Orwell, a staunch believer in democratic socialism and member of the anti-Stalinist Left, modelled the Britain under authoritarian socialism in the novel on the Soviet Union in the era of Stalinism and on the very similar practices of both censorship and propaganda in Nazi Germany. More broadly, the novel examines the role of truth and facts within societies and the ways in which they can be manipulated.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://en.wikipedia.org/wiki/Nineteen_Eighty-Four"
+          }
+        ]
+      },
+      {
+        "language": "fr",
+        "title": "1984",
+        "description": "1984 ou en toutes lettres Mil neuf cent quatre-vingt-quatre (titre original : Nineteen Eighty-Four), est un roman dystopique de l'écrivain britannique George Orwell. Publié le 8 juin 1949 par Secker & Warburg, il s'agit du neuvième et dernier livre d'Orwell achevé de son vivant. Thématiquement, il se concentre sur les conséquences du totalitarisme, de la surveillance de masse, et de l'enrégimentement répressif des personnes et des comportements au sein de la société. Orwell, fervent partisan du socialisme démocratique et membre de la gauche antistalinienne, décrit dans son roman une Grande-Bretagne, trente ans après une guerre nucléaire entre l'Est et l'Ouest censée avoir eu lieu dans les années 1950, et où s'est instauré un régime totalitaire fortement inspiré à la fois de certains éléments du stalinisme et du nazisme. Plus largement, le roman examine le rôle de la vérité et des faits au sein des sociétés et les manières dont ils peuvent être manipulés.",
+        "links": [
+          {
+            "source": "wikipedia",
+            "value": "https://fr.wikipedia.org/wiki/1984_(roman)"
+          }
+        ]
+      }
+    ]
   }
 ]

--- a/catalog/src/data/catalog-editions.json
+++ b/catalog/src/data/catalog-editions.json
@@ -534,5 +534,93 @@
     "book": "e568c46d-15a3-42a0-9690-f785252a6348",
     "language": "fr",
     "summary": "Joseph K. , cadre de banque, est arrêté chez lui, un beau matin, sans raison, le jour de son trentième anniversaire. Si on le laisse libre d'aller et venir, il ne cesse de se heurter à des obstacles absurdes, à des êtres étranges, à une réalité qui semble se dérober à mesure qu'il tente de percer le mystère de son \"arrestation\". Une justice invisible mais menaçante, qui ne définit jamais la faute qu'il a pu commettre, le cerne de toutes parts.\nLe Procès, que Kafka considérait comme inachevé, et qui parut en 1925, moins d'un an après sa mort, est un livre d'une originalité radicale, sans sources ni modèles, qui entraîne son personnage, tout comme les lecteurs, sur un terrain de plus en plus instable, à la manière des sables mouvants. Avec une notice de Régis Quatresous : \"Traduire, retraduire Le Procès. Pour saluer Alexandre Vialatte\"."
+  },
+  {
+    "isbn": "9782266199667",
+    "title": "Cabot-Caboche",
+    "publicationDate": "2011-11-07",
+    "book": "f4d4542f-9fd3-44e8-8052-5ff63bf1b53c",
+    "language": "fr",
+    "summary": "Courageux, Le Chien ! Pas joli, joli, mais un sacré cabot ! Comme il se bagarre pour vivre ! Ce qu'il cherche ? Une maîtresse. Une vraie, qui l'aime pour de bon. Pomme lui plaît beaucoup, au Chien. Un grand rire, des cheveux comme un soleil... Hélas, elle est tellement capricieuse ! Une vraie caboche, cette Pomme. Comment Le Chien va-t-il l'apprivoiser ?"
+  },
+  {
+    "isbn": "9782070403691",
+    "title": "Au bonheur des ogres",
+    "publicationDate": "2000-09-19",
+    "book": "fbd4d363-102c-419d-a6dc-67180a4ccb5d",
+    "language": "fr",
+    "summary": "Côté famille, maman s'est tirée une fois de plus en m'abandonnant les mômes, et le Petit s'est mis à rêver d'ogres Noël. Côté coeur, tante Julia a été séduite par ma nature de bouc (de bouc émissaire). Côté boulot, la première bombe a explosé au rayon des jouets, cinq minutes après mon passage. La deuxième, quinze jours plus tard, au rayon des pulls, sous mes yeux. Comme j'étais là aussi pour l'explosion de la troisième, ils m'ont tous soupçonné.\nPourquoi moi ? Je dois avoir un don..."
+  },
+  {
+    "isbn": "9782070403707",
+    "title": "La Fée Carabine",
+    "publicationDate": "2000-09-19",
+    "book": "ea6cc5dc-2f1a-4baa-88b5-6c1f5cb34965",
+    "language": "fr",
+    "summary": "\"Si les vieilles dames se mettent à buter les jeunots, si les doyens du troisième âge se shootent comme des collégiens, si les commissaires divisionnaires enseignent le vol à la tire à leurs petits-enfants, et si on prétend que tout ça c'est ma faute, moi, je pose la question : où va-t-on ? \" Ainsi s'interroge Benjamin Malaussène, bouc émissaire professionnel, payé pour endosser nos erreurs à tous, frère de famille élevant les innombrables enfants de sa mère, coeur extensible abritant chez lui les vieillards les plus drogués de la capitale, amant fidèle, ami infaillible, maître affectueux d'un chien épileptique, Benjamin Malaussène, l'innocence même (\"l'innocence m'aime\") et pourtant...\npourtant, le coupable idéal pour tous les flics de la capitale."
+  },
+  {
+    "isbn": "9782070388905",
+    "title": "Comme un roman",
+    "publicationDate": "1997-10-03",
+    "book": "bdd603ba-43f3-4253-9b30-8e0c864a03f7",
+    "language": "fr",
+    "summary": "Les droits imprescriptibles du lecteur1. Le droit de ne pas lire. 2. Le droit de sauter des pages. 3. Le droit de ne pas finir un livre. 4. Le droit de relire. 5. Le droit de lire n'importe quoi. 6. Le droit au bovarysme (maladie textuellement transmissible). 7. Le droit de lire n'importe où. 8. Le droit de grappiller. 9. Le droit de lire à haute voix. 10. Le droit de nous taire."
+  },
+  {
+    "isbn": "9781529032710",
+    "title": "Homage to Catalonia",
+    "publicationDate": "2021-04-03",
+    "book": "e1030011-98d0-48b6-bc68-3176c4ec0dd9",
+    "language": "en",
+    "summary": "Homage to Catalonia remains one of the most famous accounts of the Spanish Civil War. With characteristic scrutiny, Orwell questions the actions and motives of all sides whilst retaining his firm beliefs in human courage and the need for radical social change."
+  },
+  {
+    "isbn": "9782264030382",
+    "title": "Hommage à la Catalogne (1936-1937)",
+    "publicationDate": "2000-01-06",
+    "book": "e1030011-98d0-48b6-bc68-3176c4ec0dd9",
+    "language": "fr",
+    "summary": "Texte fondateur qui préfigure en partie les visions dramatiques du monde totalitaire de 1984 , Hommage à la Catalogne est autant un reportage qu'une réflexion sur la guerre d'Espagne. Engagé aux côtés des républicains, Orwell voit dans la trahison des communistes les conséquences du jeu politique stalinien. Il en découlera la prise de conscience d'un nécessaire engagement... \" Le texte le plus personnel et le plus émouvant de George Orwell."
+  },
+  {
+    "isbn": "9798308648314",
+    "title": "Animal Farm",
+    "publicationDate": "2025-01-28",
+    "book": "0c959d74-591c-489c-a7ca-4d7acb0ceba8",
+    "language": "en",
+    "summary": "Animal Farm is an allegorical novella by George Orwell that satirizes the events of the Russian Revolution and the emergence of Stalinism. It is a story that unfolds on a farm where animals, led by pigs, revolt against the tyrannical owner and assume control of a farm that symbolizes an egalitarian society. However, when the pigs do gain power, they turn out to be as tyrannical as their former masters, the oppressive humans. Or perhaps Orwell is attacking political corruption and inequality but also corrupting power -its abuse or how an idealistic movement can be destroyed by greed and manipulative people. In its deceptively simple yet profund narrative, George Orwell paints a powerful commentary of the dangers of totalitarianism in Animal Farm."
+  },
+  {
+    "isbn": "9782072921414",
+    "title": "La ferme des animaux - Conte de fées",
+    "publicationDate": "2021-01-02",
+    "book": "0c959d74-591c-489c-a7ca-4d7acb0ceba8",
+    "language": "fr",
+    "summary": "Un jour de juin eut lieu en Angleterre la révolte des animaux. Les cochons dirigent le nouveau régime. Boule-de-Neige et Napoléon, cochons en chef, affichent un règlement : \"Tout ce qui marche sur deux pieds est un ennemi. Tout ce qui marche sur quatre pattes, ou possède des ailes, est un ami. Nul animal ne portera de vêtements. Nul animal ne dormira dans un lit. Nul animal ne boira d'alcool. Nul animal ne tuera un autre animal.\nTous les animaux sont égaux\". Le temps passe. La pluie efface les commandements. L'âne, un cynique, arrive encore à déchiffrer : \"Tous les animaux sont égaux, mais certains animaux sont plus égaux que d'autres\"."
+  },
+  {
+    "isbn": "9782701196749",
+    "title": "La ferme des animaux",
+    "publicationDate": "2016-08-05",
+    "book": "0c959d74-591c-489c-a7ca-4d7acb0ceba8",
+    "language": "fr",
+    "summary": "A la ferme du Manoir, la révolte gronde. Entraînés par les cochons, les animaux chassent l'homme qui les exploitait et prennent le pouvoir. Ils rêvent d'instaurer une démocratie dans laquelle chacun participera aux décisions et travaillera à sa mesure. Mais chassez la tyrannie, elle revient au galop. A travers cette fable à l'humour grinçant, George Orwell compose une virulente dénonciation du totalitarisme et invite à réfléchir sur la nature humaine."
+  },
+  {
+    "isbn": "9780141187761",
+    "title": "Nineteen-Eighty-Four",
+    "publicationDate": "2008-07-03",
+    "book": "ace93305-508e-490c-ad93-f69d4beeb7a4",
+    "language": "en",
+    "summary": "'Who controls the past controls the future: who controls the present controls the past' Hidden away in the Record Department of the sprawling Ministry of Truth, Winston Smith skilfully rewrites the past to suit the needs of the Party. Yet he inwardly rebels against the totalitarian world he lives in, which demands absolute obedience and controls him through the all-seeing telescreens and the watchful eye of Big Brother, symbolic head of the Party. In his longing for truth and liberty, Smith begins a secret love affair with a fellow-worker Julia, but soon discovers the true price of freedom is betrayal. George Orwell's dystopian masterpiece, Nineteen Eighty-Four is perhaps the most pervasively influential book of the twentieth century."
+  },
+  {
+    "isbn": "9782072878497",
+    "title": "1984",
+    "publicationDate": "2020-05-28",
+    "book": "ace93305-508e-490c-ad93-f69d4beeb7a4",
+    "language": "fr",
+    "summary": "Année 1984 en Océanie. 1984 ? C'est en tout cas ce qu'il semble à Winston, qui ne saurait toutefois en jurer. Le passé a été oblitéré et réinventé, et les événements les plus récents sont susceptibles d'être modifiés. Winston est lui-même chargé de récrire les archives qui contredisent le présent et les promesses de Big Brother. Grâce à une technologie de pointe, ce dernier sait tout, voit tout. Il n'est pas une âme dont il ne puisse connaître les pensées.\nOn ne peut se fier à personne et les enfants sont encore les meilleurs espions qui soient. Liberté est Servitude. Ignorance est Puissance. Telles sont les devises du régime de Big Brother. La plupart des Océaniens n'y voient guère à redire, surtout les plus jeunes qui n'ont pas connu l'époque de leurs grands-parents et le sens initial du mot \"libre\". Winston refuse cependant de perdre espoir. Il entame une liaison secrète et hautement dangereuse avec l'insoumise Julia et tous deux vont tenter d'intégrer la Fraternité, une organisation ayant pour but de renverser Big Brother.\nMais celui-ci veille..."
   }
 ]

--- a/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/authors/AuthorDetailsModelAssembler.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/authors/AuthorDetailsModelAssembler.java
@@ -9,7 +9,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class AuthorDetailsModelAssembler extends RepresentationModelAssemblerSupport<Author, AuthorDetailsModel> {
+class AuthorDetailsModelAssembler extends RepresentationModelAssemblerSupport<Author, AuthorDetailsModel> {
     public AuthorDetailsModelAssembler() {
         super(AuthorsController.class, AuthorDetailsModel.class);
     }

--- a/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/books/BookModel.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/books/BookModel.java
@@ -1,27 +1,32 @@
 package org.adhuc.library.catalog.adapter.rest.books;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import org.adhuc.library.catalog.authors.Author;
 import org.adhuc.library.catalog.books.Book;
 import org.springframework.hateoas.RepresentationModel;
 
+import java.util.Comparator;
+import java.util.List;
 import java.util.UUID;
 
 import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
 
 @SuppressWarnings("FieldCanBeLocal")
 @JsonAutoDetect(fieldVisibility = ANY)
-public class BookDetailsModel extends RepresentationModel<BookDetailsModel> {
+public class BookModel extends RepresentationModel<BookModel> {
     private final UUID id;
     private final String title;
     private final String description;
+    private final List<UUID> authors;
 
-    BookDetailsModel(Book book) {
+    BookModel(Book book) {
         this(book, book.originalLanguage());
     }
 
-    BookDetailsModel(Book book, String language) {
+    BookModel(Book book, String language) {
         this.id = book.id();
         this.title = book.titleIn(language);
         this.description = book.descriptionIn(language);
+        this.authors = book.authors().stream().sorted(Comparator.comparing(Author::name)).map(Author::id).toList();
     }
 }

--- a/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/books/BookModelAssembler.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/books/BookModelAssembler.java
@@ -1,0 +1,30 @@
+package org.adhuc.library.catalog.adapter.rest.books;
+
+import org.adhuc.library.catalog.books.Book;
+import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class BookModelAssembler extends RepresentationModelAssemblerSupport<Book, BookModel> {
+    public BookModelAssembler() {
+        super(BooksController.class, BookModel.class);
+    }
+
+    @NonNull
+    @Override
+    public BookModel toModel(@NonNull Book book) {
+        var model = instantiateModel(book);
+        model.add(linkTo(methodOn(BooksController.class).getBook(book.id(), null)).withSelfRel());
+        return model;
+    }
+
+    @NonNull
+    @Override
+    protected BookModel instantiateModel(@NonNull Book book) {
+        return new BookModel(book);
+    }
+}

--- a/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/editions/EditionDetailsModelAssembler.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/editions/EditionDetailsModelAssembler.java
@@ -1,5 +1,6 @@
 package org.adhuc.library.catalog.adapter.rest.editions;
 
+import org.adhuc.library.catalog.adapter.rest.books.BooksController;
 import org.adhuc.library.catalog.editions.Edition;
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
 import org.springframework.lang.NonNull;
@@ -9,7 +10,7 @@ import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
 import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
 
 @Component
-public class EditionDetailsModelAssembler extends RepresentationModelAssemblerSupport<Edition, EditionDetailsModel> {
+class EditionDetailsModelAssembler extends RepresentationModelAssemblerSupport<Edition, EditionDetailsModel> {
     public EditionDetailsModelAssembler() {
         super(EditionsController.class, EditionDetailsModel.class);
     }
@@ -19,6 +20,7 @@ public class EditionDetailsModelAssembler extends RepresentationModelAssemblerSu
     public EditionDetailsModel toModel(@NonNull Edition edition) {
         var model = instantiateModel(edition);
         model.add(linkTo(methodOn(EditionsController.class).getEdition(edition.isbn())).withSelfRel());
+        model.add(linkTo(methodOn(BooksController.class).getBook(edition.book().id(), null)).withRel("book"));
         return model;
     }
 

--- a/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/editions/EditionModelAssembler.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/adapter/rest/editions/EditionModelAssembler.java
@@ -1,5 +1,6 @@
 package org.adhuc.library.catalog.adapter.rest.editions;
 
+import org.adhuc.library.catalog.adapter.rest.books.BooksController;
 import org.adhuc.library.catalog.editions.Edition;
 import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
 import org.springframework.lang.NonNull;
@@ -19,6 +20,7 @@ public class EditionModelAssembler extends RepresentationModelAssemblerSupport<E
     public EditionModel toModel(@NonNull Edition edition) {
         var model = instantiateModel(edition);
         model.add(linkTo(methodOn(EditionsController.class).getEdition(edition.isbn())).withSelfRel());
+        model.add(linkTo(methodOn(BooksController.class).getBook(edition.book().id(), null)).withRel("book"));
         return model;
     }
 

--- a/catalog/src/main/java/org/adhuc/library/catalog/books/BooksRepository.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/books/BooksRepository.java
@@ -1,9 +1,15 @@
 package org.adhuc.library.catalog.books;
 
+import org.adhuc.library.catalog.editions.Edition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
 import java.util.Optional;
 import java.util.UUID;
 
 public interface BooksRepository {
+
+    Page<Book> find(Pageable request);
 
     Optional<Book> findById(UUID id);
 

--- a/catalog/src/main/java/org/adhuc/library/catalog/books/CatalogService.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/books/CatalogService.java
@@ -1,4 +1,4 @@
-package org.adhuc.library.catalog.editions;
+package org.adhuc.library.catalog.books;
 
 import org.jmolecules.architecture.onion.classical.ApplicationServiceRing;
 import org.springframework.data.domain.Page;
@@ -10,13 +10,13 @@ import org.springframework.util.Assert;
 @ApplicationServiceRing
 public class CatalogService {
 
-    private final EditionsRepository repository;
+    private final BooksRepository repository;
 
-    CatalogService(EditionsRepository repository) {
+    CatalogService(BooksRepository repository) {
         this.repository = repository;
     }
 
-    public Page<Edition> getPage(Pageable request) {
+    public Page<Book> getPage(Pageable request) {
         Assert.notNull(request, "Cannot get catalog page from null request");
         return repository.find(request);
     }

--- a/catalog/src/main/java/org/adhuc/library/catalog/books/internal/InMemoryBooksRepository.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/books/internal/InMemoryBooksRepository.java
@@ -3,6 +3,9 @@ package org.adhuc.library.catalog.books.internal;
 import org.adhuc.library.catalog.books.Book;
 import org.adhuc.library.catalog.books.BooksRepository;
 import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
@@ -15,6 +18,12 @@ public class InMemoryBooksRepository implements BooksRepository {
 
     public Collection<Book> findAll() {
         return List.copyOf(books);
+    }
+
+    @Override
+    public Page<Book> find(Pageable request) {
+        var pageBooks = books.stream().skip(request.getOffset()).limit(request.getPageSize()).toList();
+        return new PageImpl<>(pageBooks, request, books.size());
     }
 
     @Override

--- a/catalog/src/main/java/org/adhuc/library/catalog/editions/EditionsRepository.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/editions/EditionsRepository.java
@@ -1,8 +1,6 @@
 package org.adhuc.library.catalog.editions;
 
 import org.jmolecules.architecture.onion.classical.DomainServiceRing;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 
 import java.util.Collection;
 import java.util.Optional;
@@ -11,9 +9,9 @@ import java.util.UUID;
 @DomainServiceRing
 public interface EditionsRepository {
 
-    Page<Edition> find(Pageable request);
-
     Optional<Edition> findByIsbn(String isbn);
+
+    Collection<Edition> findByBookIds(Collection<UUID> bookIds);
 
     Collection<Edition> findNotableByAuthor(UUID authorId);
 

--- a/catalog/src/main/java/org/adhuc/library/catalog/editions/EditionsService.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/editions/EditionsService.java
@@ -23,9 +23,13 @@ public class EditionsService {
         return repository.findByIsbn(isbn);
     }
 
+    public Collection<Edition> getBooksEditions(Collection<UUID> bookIds) {
+        Assert.notNull(bookIds, "Cannot get book editions from null books list");
+        return repository.findByBookIds(bookIds);
+    }
+
     public Collection<Edition> getNotableEditions(UUID authorId) {
         Assert.notNull(authorId, "Cannot get notable editions from null author ID");
         return repository.findNotableByAuthor(authorId);
     }
-
 }

--- a/catalog/src/main/java/org/adhuc/library/catalog/editions/internal/InMemoryEditionsRepository.java
+++ b/catalog/src/main/java/org/adhuc/library/catalog/editions/internal/InMemoryEditionsRepository.java
@@ -3,9 +3,6 @@ package org.adhuc.library.catalog.editions.internal;
 import org.adhuc.library.catalog.editions.Edition;
 import org.adhuc.library.catalog.editions.EditionsRepository;
 import org.jmolecules.architecture.onion.classical.InfrastructureRing;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.*;
@@ -21,16 +18,17 @@ public class InMemoryEditionsRepository implements EditionsRepository {
     }
 
     @Override
-    public Page<Edition> find(Pageable request) {
-        var pageEditions = editions.stream().skip(request.getOffset()).limit(request.getPageSize()).toList();
-        return new PageImpl<>(pageEditions, request, editions.size());
-    }
-
-    @Override
     public Optional<Edition> findByIsbn(String isbn) {
         return editions.stream()
                 .filter(edition -> edition.isbn().equals(isbn))
                 .findFirst();
+    }
+
+    @Override
+    public Collection<Edition> findByBookIds(Collection<UUID> bookIds) {
+        return editions.stream()
+                .filter(edition -> bookIds.contains(edition.book().id()))
+                .toList();
     }
 
     @Override

--- a/catalog/src/main/resources/api/openapi.yml
+++ b/catalog/src/main/resources/api/openapi.yml
@@ -9,15 +9,15 @@ servers:
   - url: https://catalog.library.adhuc.org/api
 tags:
   - name: Books
-    description: Access the editions in the catalog of the library.
+    description: Access the books and their editions in the catalog of the library.
   - name: Authors
-    description: Access the authors of the editions in the catalog of the library.
+    description: Access the authors of the books in the catalog of the library.
 paths:
   /v1/catalog:
     get:
       tags:
         - Books
-      summary: Gets a paginated list of editions based on filters.
+      summary: Gets a paginated list of books based on filters.
       description: The catalog can be sorted and filtered in many different ways.
       operationId: getCatalog
       parameters:
@@ -308,14 +308,26 @@ components:
           type: object
           readOnly: true
           required:
-            - editions
+            - books
             - authors
           properties:
+            books:
+              description: |
+                The books collection, containing basic information for each book.
+              type: array
+              items:
+                $ref: '#/components/schemas/Book'
             editions:
-              description: The book editions collection, containing basic information for each edition.
+              description: |
+                The book editions corresponding to the books in the collection,
+                containing basic information for each edition.
+
+                This field is deprecated and will be replaced by the books and
+                their editions.
               type: array
               items:
                 $ref: '#/components/schemas/Edition'
+              deprecated: true
             authors:
               description: The authors related to the editions in the collection.
               type: array
@@ -512,7 +524,6 @@ components:
       required:
         - isbn
         - title
-        - authors
         - language
         - summary
         - '_links'
@@ -521,8 +532,6 @@ components:
           $ref: '#/components/schemas/ISBN'
         title:
           $ref: '#/components/schemas/Title'
-        authors:
-          $ref: '#/components/schemas/BookAuthors'
         language:
           $ref: '#/components/schemas/Language'
         summary:
@@ -532,9 +541,12 @@ components:
           readOnly: true
           required:
             - self
+            - book
           properties:
             self:
               $ref: '#/components/schemas/EditionLink'
+            book:
+              $ref: '#/components/schemas/BookLink'
     EditionDetails:
       type: object
       required:
@@ -560,6 +572,7 @@ components:
           readOnly: true
           required:
             - self
+            - book
           properties:
             self:
               $ref: '#/components/schemas/EditionLink'
@@ -662,7 +675,7 @@ components:
           required:
             - notable_books
           properties:
-            books:
+            notable_books:
               description: The author's editions, containing basic information for each book.
               type: array
               items:

--- a/catalog/src/test/java/org/adhuc/library/catalog/adapter/rest/catalog/CatalogControllerPactTests.java
+++ b/catalog/src/test/java/org/adhuc/library/catalog/adapter/rest/catalog/CatalogControllerPactTests.java
@@ -8,10 +8,11 @@ import au.com.dius.pact.provider.junitsupport.State;
 import au.com.dius.pact.provider.junitsupport.loader.PactBroker;
 import org.adhuc.library.catalog.authors.Author;
 import org.adhuc.library.catalog.books.Book;
+import org.adhuc.library.catalog.books.CatalogService;
 import org.adhuc.library.catalog.books.ExternalLink;
 import org.adhuc.library.catalog.books.LocalizedDetails;
-import org.adhuc.library.catalog.editions.CatalogService;
 import org.adhuc.library.catalog.editions.Edition;
+import org.adhuc.library.catalog.editions.EditionsService;
 import org.adhuc.library.catalog.editions.PublicationDate;
 import org.apache.hc.core5.http.HttpRequest;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,8 @@ class CatalogControllerPactTests {
     int port;
     @MockitoBean
     private CatalogService catalogService;
+    @MockitoBean
+    private EditionsService editionsService;
 
     @BeforeEach
     void setUp(PactVerificationContext context) {
@@ -53,66 +56,74 @@ class CatalogControllerPactTests {
 
     @State("First page of 10 elements contains editions")
     void page0Size10() {
+        var bookId = UUID.fromString("b6608a30-1e9b-4ae0-a89d-624c3ca85da4");
+        var book = new Book(
+                bookId,
+                Set.of(new Author(
+                        UUID.fromString("83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"),
+                        "Jean-Jacques Rousseau",
+                        LocalDate.parse("1712-06-28"),
+                        LocalDate.parse("1778-07-02")
+                )),
+                "fr",
+                Set.of(new LocalizedDetails(
+                        "fr",
+                        "Du contrat social",
+                        "Du contrat social est un traité de philosophie politique présentant ...",
+                        Set.of(
+                                new ExternalLink("wikipedia", "https://fr.wikipedia.org/wiki/Du_contrat_social")
+                        )
+                ))
+        );
+
         var request = PageRequest.of(0, 10);
-        when(catalogService.getPage(request)).thenReturn(new PageImpl<>(List.of(
+        when(catalogService.getPage(request)).thenReturn(new PageImpl<>(List.of(book), request, 67));
+        when(editionsService.getBooksEditions(List.of(bookId))).thenReturn(List.of(
                 new Edition(
                         "9782081275232",
                         "Du contrat social",
                         PublicationDate.of(LocalDate.parse("2012-01-04")),
-                        new Book(
-                                UUID.fromString("b6608a30-1e9b-4ae0-a89d-624c3ca85da4"),
-                                Set.of(new Author(
-                                        UUID.fromString("83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"),
-                                        "Jean-Jacques Rousseau",
-                                        LocalDate.parse("1712-06-28"),
-                                        LocalDate.parse("1778-07-02")
-                                )),
-                                "fr",
-                                Set.of(new LocalizedDetails(
-                                        "fr",
-                                        "Du contrat social",
-                                        "Du contrat social est un traité de philosophie politique présentant ...",
-                                        Set.of(
-                                                new ExternalLink("wikipedia", "https://fr.wikipedia.org/wiki/Du_contrat_social")
-                                        )
-                                ))
-                        ),
+                        book,
                         "fr",
                         "Paru en 1762, le Contrat social, ..."
                 )
-        ), request, 67));
+        ));
     }
 
     @State("Next page of 25 elements contains editions")
     void page1Size25() {
+        var bookId = UUID.fromString("b6608a30-1e9b-4ae0-a89d-624c3ca85da4");
+        var book = new Book(
+                bookId,
+                Set.of(new Author(
+                        UUID.fromString("83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"),
+                        "Jean-Jacques Rousseau",
+                        LocalDate.parse("1712-06-28"),
+                        LocalDate.parse("1778-07-02")
+                )),
+                "fr",
+                Set.of(new LocalizedDetails(
+                        "fr",
+                        "Du contrat social",
+                        "Du contrat social est un traité de philosophie politique présentant ...",
+                        Set.of(
+                                new ExternalLink("wikipedia", "https://fr.wikipedia.org/wiki/Du_contrat_social")
+                        )
+                ))
+        );
+
         var request = PageRequest.of(1, 25);
-        when(catalogService.getPage(request)).thenReturn(new PageImpl<>(List.of(
+        when(catalogService.getPage(request)).thenReturn(new PageImpl<>(List.of(book), request, 67));
+        when(editionsService.getBooksEditions(List.of(bookId))).thenReturn(List.of(
                 new Edition(
                         "9782081275232",
                         "Du contrat social",
                         PublicationDate.of(LocalDate.parse("2012-01-04")),
-                        new Book(
-                                UUID.fromString("b6608a30-1e9b-4ae0-a89d-624c3ca85da4"),
-                                Set.of(new Author(
-                                        UUID.fromString("83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725"),
-                                        "Jean-Jacques Rousseau",
-                                        LocalDate.parse("1712-06-28"),
-                                        LocalDate.parse("1778-07-02")
-                                )),
-                                "fr",
-                                Set.of(new LocalizedDetails(
-                                        "fr",
-                                        "Du contrat social",
-                                        "Du contrat social est un traité de philosophie politique présentant ...",
-                                        Set.of(
-                                                new ExternalLink("wikipedia", "https://fr.wikipedia.org/wiki/Du_contrat_social")
-                                        )
-                                ))
-                        ),
+                        book,
                         "fr",
                         "Paru en 1762, le Contrat social, ..."
                 )
-        ), request, 67));
+        ));
     }
 
 }

--- a/catalog/src/test/java/org/adhuc/library/catalog/adapter/rest/editions/EditionsControllerTests.java
+++ b/catalog/src/test/java/org/adhuc/library/catalog/adapter/rest/editions/EditionsControllerTests.java
@@ -98,7 +98,8 @@ class EditionsControllerTests {
                 .andExpect(jsonPath("publication_date", equalTo(edition.publicationDate().toString())))
                 .andExpect(jsonPath("language", equalTo(edition.language())))
                 .andExpect(jsonPath("summary", equalTo(edition.summary())))
-                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/editions/\{edition.isbn()}")));
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/editions/\{edition.isbn()}")))
+                .andExpect(jsonPath("_links.book.href", equalTo(STR."http://localhost/api/v1/books/\{edition.book().id()}")));
 
         assertResponseContainsAllEmbeddedAuthors(result, edition.book().authors());
 

--- a/catalog/src/test/java/org/adhuc/library/catalog/books/CatalogServiceTests.java
+++ b/catalog/src/test/java/org/adhuc/library/catalog/books/CatalogServiceTests.java
@@ -1,6 +1,6 @@
-package org.adhuc.library.catalog.editions;
+package org.adhuc.library.catalog.books;
 
-import org.adhuc.library.catalog.editions.internal.InMemoryEditionsRepository;
+import org.adhuc.library.catalog.books.internal.InMemoryBooksRepository;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.data.domain.PageRequest;
 
-import static org.adhuc.library.catalog.editions.EditionsMother.editions;
+import static org.adhuc.library.catalog.books.BooksMother.books;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -18,12 +18,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 class CatalogServiceTests {
 
     private CatalogService service;
-    private InMemoryEditionsRepository editionsRepository;
+    private InMemoryBooksRepository booksRepository;
 
     @BeforeEach
     void setUp() {
-        editionsRepository = new InMemoryEditionsRepository();
-        service = new CatalogService(editionsRepository);
+        booksRepository = new InMemoryBooksRepository();
+        service = new CatalogService(booksRepository);
     }
 
     @Test
@@ -40,18 +40,18 @@ class CatalogServiceTests {
             "10, 100"
     })
     @DisplayName("return an empty page when the catalog is empty")
-    void getEmptyPageNoEditionInCatalog(int number, int size) {
+    void getEmptyPageNoBookInCatalog(int number, int size) {
         var page = service.getPage(PageRequest.of(number, size));
         assertThat(page.isEmpty()).isTrue();
     }
 
     @Nested
-    @DisplayName("when 106 editions are in the catalog")
-    class EditionsInCatalogTests {
+    @DisplayName("when 106 books are in the catalog")
+    class BooksInCatalogTests {
 
         @BeforeEach
         void setUp() {
-            editionsRepository.saveAll(editions().list().ofSize(106).sample());
+            booksRepository.saveAll(books().list().ofSize(106).sample());
         }
 
         @ParameterizedTest
@@ -68,7 +68,7 @@ class CatalogServiceTests {
                 "0, 53, 2, 106",
                 "1, 37, 3, 106"
         })
-        @DisplayName("return a full page of editions when requested page is not beyond the catalog size")
+        @DisplayName("return a full page of books when requested page is not beyond the catalog size")
         void getFullPage(int number, int size, int totalPages, int totalElements) {
             var page = service.getPage(PageRequest.of(number, size));
             SoftAssertions.assertSoftly(s -> {
@@ -89,7 +89,7 @@ class CatalogServiceTests {
                 "1, 100, 6, 2, 106",
                 "2, 37, 32, 3, 106"
         })
-        @DisplayName("return a partial page of editions when requested page reaches the end of the catalog")
+        @DisplayName("return a partial page of books when requested page reaches the end of the catalog")
         void getPartialPage(int number, int size, int elements, int totalPages, int totalElements) {
             var page = service.getPage(PageRequest.of(number, size));
             SoftAssertions.assertSoftly(s -> {
@@ -111,7 +111,7 @@ class CatalogServiceTests {
                 "2, 53",
                 "3, 37"
         })
-        @DisplayName("return an empty page of editions when requested page is beyond the catalog size")
+        @DisplayName("return an empty page of books when requested page is beyond the catalog size")
         void getEmptyPageBeyondSize(int number, int size) {
             var page = service.getPage(PageRequest.of(number, size));
             assertThat(page.isEmpty()).isTrue();


### PR DESCRIPTION
The main embedded data in the catalog is now books. The editions will be deduced from the books found in each page of the catalog, to be removed in a future release.