### PR TITLE
fix: Adapt website catalog pages URL after navigation

### DIFF
--- a/website/src/main/java/org/adhuc/library/website/catalog/CatalogClient.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/CatalogClient.java
@@ -6,6 +6,8 @@ public interface CatalogClient {
 
     NavigablePage<Book> listBooks(String acceptLanguages);
 
+    NavigablePage<Book> listBooks(int pageNumber, String acceptLanguages);
+
     NavigablePage<Book> listBooks(NavigablePage<Book> current, String linkName, String acceptLanguages);
 
     Book getBook(String id, String acceptLanguages);

--- a/website/src/main/java/org/adhuc/library/website/catalog/CatalogController.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/CatalogController.java
@@ -1,7 +1,6 @@
 package org.adhuc.library.website.catalog;
 
 import org.adhuc.library.website.support.pagination.NavigablePage;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -46,6 +45,18 @@ public class CatalogController {
         }
     }
 
+    @GetMapping("/{page}")
+    public String catalog(Model model, @PathVariable(name = "page") int pageNumber,
+                          @RequestHeader(name = ACCEPT_LANGUAGE, required = false, defaultValue = "") String acceptLanguages) {
+        try {
+            var page = catalogClient.listBooks(pageNumber, acceptLanguages);
+            return browsePage(model, page);
+        } catch (IllegalArgumentException e) {
+            model.addAttribute("message", e.getMessage());
+            return "error";
+        }
+    }
+
     @GetMapping("/books/{id}")
     public String bookDetail(Model model, @PathVariable String id,
                              @RequestHeader(name = ACCEPT_LANGUAGE, required = false, defaultValue = "") String acceptLanguages) {
@@ -70,6 +81,7 @@ public class CatalogController {
 
     private void fillModel(Model model, NavigablePage<Book> booksPage) {
         model.addAttribute("books", booksPage.getContent());
+        model.addAttribute("pageUrl", "/catalog/" + booksPage.getNumber());
         pageAttributes.forEach(pageAttribute -> pageAttribute.addToModel(booksPage, model));
     }
 

--- a/website/src/main/java/org/adhuc/library/website/catalog/internal/CatalogRestClient.java
+++ b/website/src/main/java/org/adhuc/library/website/catalog/internal/CatalogRestClient.java
@@ -29,7 +29,12 @@ class CatalogRestClient implements CatalogClient {
 
     @Override
     public NavigablePage<Book> listBooks(String acceptLanguages) {
-        return listBooks(PageRequest.of(0, 10), acceptLanguages);
+        return listBooks(0, acceptLanguages);
+    }
+
+    @Override
+    public NavigablePage<Book> listBooks(int pageNumber, String acceptLanguages) {
+        return listBooks(PageRequest.of(pageNumber, 10), acceptLanguages);
     }
 
     NavigablePage<Book> listBooks(Pageable pageable, String acceptLanguages) {

--- a/website/src/main/resources/templates/catalog/root.html
+++ b/website/src/main/resources/templates/catalog/root.html
@@ -30,6 +30,11 @@
     </tr>
     </tbody>
 </table>
-
+<script th:inline="javascript">
+    let pageUrl = "[(${pageUrl})]";
+    window.addEventListener("load", (event) => {
+        history.replaceState(null, "", pageUrl);
+    });
+</script>
 </body>
 </html>

--- a/website/src/main/resources/templates/fragments/layout.html
+++ b/website/src/main/resources/templates/fragments/layout.html
@@ -46,7 +46,7 @@
     </div>
 </div>
 
-<script th:src="@{/webjars/bootstrap/5.3.5/dist/js/bootstrap.bundle.min.js}"></script>
+<script th:src="@{/webjars/bootstrap/5.3.6/dist/js/bootstrap.bundle.min.js}"></script>
 
 </body>
 


### PR DESCRIPTION
This fix ensures that library members can use the browser history to go back or forward, and bookmark or share catalog pages