### PR TITLE
feat: Add link to navigate back to the catalog from a book detail page

### DIFF
--- a/website/src/main/resources/i18n/messages.properties
+++ b/website/src/main/resources/i18n/messages.properties
@@ -4,6 +4,8 @@ home.greeting=Welcome to the library
 menu.home=Home
 menu.catalog=Browse catalog
 
+navigation.back.catalog=Go back to the catalog
+
 error.header=Something happened...
 
 catalog.header=Books catalog

--- a/website/src/main/resources/i18n/messages_en.properties
+++ b/website/src/main/resources/i18n/messages_en.properties
@@ -4,6 +4,8 @@ home.greeting=Welcome to the library
 menu.home=Home
 menu.catalog=Browse catalog
 
+navigation.back.catalog=Go back to the catalog
+
 error.header=Something happened...
 
 catalog.header=Books catalog

--- a/website/src/main/resources/i18n/messages_fr.properties
+++ b/website/src/main/resources/i18n/messages_fr.properties
@@ -4,6 +4,8 @@ home.greeting=Bienvenue dans la bibliothèque
 menu.home=Accueil
 menu.catalog=Parcourir le catalogue
 
+navigation.back.catalog=Retour au catalogue
+
 error.header=Une erreur est survenue...
 
 catalog.header=Catalogue des ouvrages

--- a/website/src/main/resources/templates/catalog/book-detail.html
+++ b/website/src/main/resources/templates/catalog/book-detail.html
@@ -3,6 +3,11 @@
 <html xmlns:th="https://www.thymeleaf.org" th:replace="~{fragments/layout :: layout (~{::body},'catalog')}">
 <body>
 
+<div id="historyBack">
+    <a href="" onclick="history.back()">&lt; <span th:text="#{navigation.back.catalog}"></span></a>
+    <hr />
+</div>
+
 <h2 th:text="${book.title}"></h2>
 <h3>
     <span th:each="author, iStat : ${book.authors}">


### PR DESCRIPTION
The link is always present but does effectively go back to the catalog previous page, or whatever previous browsed page, if the book detail page is not the first browsed page in the window or tab.