### PR TITLE
feat: Provide API to reference authors

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ declare properties that will be used during execution. By default, those values 
 ```properties
 PACT_BROKER_PORT=9292
 CATALOG_API_PORT=8080
+REFERENCING_API_PORT=8081
 WEBSITE_PORT=9000
 ZIPKIN_PORT=9411
 ```
@@ -120,6 +121,7 @@ By default, each application exposing an API provides a Swagger UI to browse the
 running the applications with `make start`, you will have access to those API documentation pages:
 
 - [Catalog API](https://localhost:8080/swagger-ui/index.html)
+- [Referencing API](https://localhost:8081/swagger-ui/index.html)
 
 ### HTTP2 activation
 

--- a/referencing/build.gradle
+++ b/referencing/build.gradle
@@ -63,6 +63,7 @@ dependencies {
 	testImplementation 'net.datafaker:datafaker:2.5.1'
 	testImplementation 'au.com.dius.pact.provider:junit5:4.6.17'
 
+	acceptanceImplementation 'org.jspecify:jspecify:1.0.0'
 	acceptanceImplementation platform('io.cucumber:cucumber-bom:7.23.0')
 	acceptanceImplementation 'io.cucumber:cucumber-java'
 	acceptanceImplementation 'io.cucumber:cucumber-junit-platform-engine'

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/AcceptanceTests.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/AcceptanceTests.java
@@ -1,10 +1,17 @@
 package org.adhuc.library.referencing.acceptance;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import io.cucumber.java.Before;
 import io.restassured.RestAssured;
+import io.restassured.config.ObjectMapperConfig;
+import org.jspecify.annotations.Nullable;
 import org.junit.platform.suite.api.*;
 
+import static com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PUBLISH_ENABLED_PROPERTY_NAME;
+import static io.restassured.RestAssured.config;
 
 @Suite
 @IncludeEngines("cucumber")
@@ -22,13 +29,22 @@ public class AcceptanceTests {
         var baseUrl = new ServiceUrlResolver(REFERENCING_SERVICE_NAME, REFERENCING_EXPOSED_PORT).serviceUrl();
         RestAssured.baseURI = STR."\{baseUrl}/api";
         RestAssured.useRelaxedHTTPSValidation();
+        RestAssured.config = config().objectMapperConfig(new ObjectMapperConfig().jackson2ObjectMapperFactory(
+                (type, s) -> {
+                    var mapper = new ObjectMapper();
+                    mapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+                    mapper.setSerializationInclusion(Include.NON_ABSENT);
+                    mapper.configure(FAIL_ON_UNKNOWN_PROPERTIES, false);
+                    return mapper;
+                }
+        ));
     }
 
     static class ServiceUrlResolver {
         private static final String DEFAULT_HOST = "localhost";
         private final int port;
 
-        ServiceUrlResolver(String serviceName, String exposedPort) {
+        ServiceUrlResolver(@Nullable String serviceName, @Nullable String exposedPort) {
             if (serviceName == null) {
                 throw new NullPointerException("serviceName is marked non-null but is null");
             }

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/AuthorsStepDefinitions.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/AuthorsStepDefinitions.java
@@ -1,0 +1,115 @@
+package org.adhuc.library.referencing.acceptance;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import io.restassured.response.ValidatableResponse;
+import org.adhuc.library.referencing.acceptance.authors.Author;
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Objects;
+
+import static org.adhuc.library.referencing.acceptance.authors.actions.AuthorReferencing.referenceAuthor;
+import static org.adhuc.library.referencing.acceptance.authors.actions.AuthorReferencing.referenceAuthorWithNameOnly;
+import static org.adhuc.library.referencing.acceptance.authors.actions.AuthorsListing.listAuthors;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.hamcrest.Matchers.*;
+
+public class AuthorsStepDefinitions {
+
+    @Nullable
+    private ValidatableResponse response;
+
+    @Given("{authorName} is not present in the list of authors")
+    public void authorNotPresentInList(String authorName) {
+        var authors = listAuthors();
+        var authorIsPresent = isAuthorPresentInList(authors, authorName);
+        assumeThat(authorIsPresent).as("Author should not be present").isFalse();
+    }
+
+    @Given("{authorName} born on {date} and dead on {date} is present in the list of authors")
+    public void authorPresentInList(String authorName, LocalDate dateOfBirth, LocalDate dateOfDeath) {
+        var authors = listAuthors();
+        var authorIsPresent = isAuthorPresentInList(authors, authorName);
+        if (!authorIsPresent) {
+            response = referenceAuthor(authorName, dateOfBirth, dateOfDeath);
+            response.statusCode(201);
+        }
+    }
+
+    @When("she references new author {authorName}")
+    public void referenceNewAuthorOnlyName(String authorName) {
+        response = referenceAuthorWithNameOnly(authorName);
+    }
+
+    @When("she references new author {authorName} born on {date}")
+    public void referenceNewAuthorBornExactDate(String authorName, LocalDate dateOfBirth) {
+        response = referenceAuthor(authorName, dateOfBirth);
+    }
+
+    @When("she references new author {authorName} born on {year}")
+    public void referenceNewAuthorBornYearDate(String authorName, int yearOfBirth) {
+    }
+
+    @When("she references new author {authorName} born on {date} and dead on {date}")
+    public void referenceNewDeadAuthorBornExactDate(String authorName, LocalDate dateOfBirth, LocalDate dateOfDeath) {
+        response = referenceAuthor(authorName, dateOfBirth, dateOfDeath);
+    }
+
+    @Then("{authorName} is referenced")
+    public void assertReferencedAuthor(String authorName) {
+        var location = Objects.requireNonNull(response, "Response must have been set before assertion")
+                .assertThat()
+                .log().ifError()
+                .statusCode(201)
+                .header("Location", notNullValue())
+                .extract().header("Location");
+        // TODO assert location is accessible and provides author
+    }
+
+    @Then("the referencing fails with date of birth required")
+    public void assertReferenceFailedMissingDateOfBirth() {
+        Objects.requireNonNull(response, "Response must have been set before assertion")
+                .assertThat()
+                .log().ifStatusCodeMatches(not(equalTo(400)))
+                .statusCode(400)
+                .header("Location", nullValue())
+                .body("type", equalTo("/problems/invalid-request"))
+                .body("title", equalTo("Request validation error"))
+                .body("errors[0].detail", equalTo("Missing required property"))
+                .body("errors[0].pointer", equalTo("date_of_birth"));
+    }
+
+    @Then("{authorName} is now present in the list of authors")
+    public void assertAuthorPresentInList(String authorName) {
+        var authors = listAuthors();
+        var authorIsPresent = isAuthorPresentInList(authors, authorName);
+        assertThat(authorIsPresent).as("Author should be present after referencing").isTrue();
+    }
+
+    @Then("{authorName} is still not present in the list of authors")
+    public void assertAuthorNotPresentInList(String authorName) {
+        var authors = listAuthors();
+        var authorIsPresent = isAuthorPresentInList(authors, authorName);
+        assertThat(authorIsPresent).as("Author should not be present after referencing").isFalse();
+    }
+
+    @Then("{authorName} is present twice in the list of authors")
+    public void assertAuthorDuplicateInList(String authorName) {
+        var authors = listAuthors();
+        var numberOfOccurrences = authorOccurrencesInList(authors, authorName);
+        assertThat(numberOfOccurrences).isEqualTo(2L);
+    }
+
+    private boolean isAuthorPresentInList(@Nullable List<Author> authors, String authorName) {
+        return authors != null && !authors.isEmpty() && authors.stream().anyMatch(author -> author.hasName(authorName));
+    }
+
+    private long authorOccurrencesInList(@Nullable List<Author> authors, String authorName) {
+        return authors == null ? 0 : authors.stream().filter(author -> author.hasName(authorName)).count();
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/LibrarianStepDefinitions.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/LibrarianStepDefinitions.java
@@ -1,0 +1,12 @@
+package org.adhuc.library.referencing.acceptance;
+
+import io.cucumber.java.en.Given;
+
+public class LibrarianStepDefinitions {
+
+    @Given("{word} is a librarian")
+    public void librarian(String name) {
+        // nothing to do here now
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/Parameters.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/Parameters.java
@@ -1,0 +1,24 @@
+package org.adhuc.library.referencing.acceptance;
+
+import io.cucumber.java.ParameterType;
+
+import java.time.LocalDate;
+
+public class Parameters {
+
+    @ParameterType("[A-Za-zÀ-ÿ][A-Za-zÀ-ÿ ]*")
+    public String authorName(String source) {
+        return source;
+    }
+
+    @ParameterType("\\d{4}-\\d{2}-\\d{2}")
+    public LocalDate date(String source) {
+        return LocalDate.parse(source);
+    }
+
+    @ParameterType("\\d{4}")
+    public int year(String source) {
+        return Integer.parseInt(source);
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/Author.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/Author.java
@@ -1,0 +1,19 @@
+package org.adhuc.library.referencing.acceptance.authors;
+
+import org.jspecify.annotations.Nullable;
+
+public record Author(@Nullable String id, String name, String dateOfBirth, @Nullable String dateOfDeath) {
+
+    public Author(String name, String dateOfBirth) {
+        this(null, name, dateOfBirth, null);
+    }
+
+    public Author(String name, String dateOfBirth, String dateOfDeath) {
+        this(null, name, dateOfBirth, dateOfDeath);
+    }
+
+    public boolean hasName(String authorName) {
+        return name.equals(authorName);
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/AuthorReferencing.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/AuthorReferencing.java
@@ -1,0 +1,44 @@
+package org.adhuc.library.referencing.acceptance.authors.actions;
+
+import io.restassured.http.ContentType;
+import io.restassured.response.ValidatableResponse;
+import org.adhuc.library.referencing.acceptance.authors.Author;
+
+import java.time.LocalDate;
+
+import static io.restassured.RestAssured.given;
+import static java.time.format.DateTimeFormatter.ISO_DATE;
+
+@SuppressWarnings("preview")
+public class AuthorReferencing {
+
+    public static ValidatableResponse referenceAuthor(String name, LocalDate dateOfBirth) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(new Author(name, dateOfBirth.format(ISO_DATE)))
+                .log().ifValidationFails()
+                .when()
+                .post("/v1/authors")
+                .then();
+    }
+
+    public static ValidatableResponse referenceAuthor(String name, LocalDate dateOfBirth, LocalDate dateOfDeath) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(new Author(name, dateOfBirth.format(ISO_DATE), dateOfDeath.format(ISO_DATE)))
+                .log().ifValidationFails()
+                .when()
+                .post("/v1/authors")
+                .then();
+    }
+
+    public static ValidatableResponse referenceAuthorWithNameOnly(String name) {
+        return given()
+                .contentType(ContentType.JSON)
+                .body(STR."{\"name\": \"\{name}\"}")
+                .when()
+                .post("/v1/authors")
+                .then();
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/AuthorsListing.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/AuthorsListing.java
@@ -1,0 +1,26 @@
+package org.adhuc.library.referencing.acceptance.authors.actions;
+
+import org.adhuc.library.referencing.acceptance.authors.Author;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+
+import static io.restassured.RestAssured.given;
+
+public class AuthorsListing {
+
+    @Nullable
+    public static List<Author> listAuthors() {
+        return given()
+                .log().ifValidationFails()
+                .when()
+                .get("/v1/authors")
+                .then()
+                .log().ifError()
+                .statusCode(206)
+                .extract()
+                .body()
+                .jsonPath().getList("_embedded.authors", Author.class);
+    }
+
+}

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/package-info.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/actions/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.adhuc.library.referencing.acceptance.authors.actions;
+
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/package-info.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/authors/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.adhuc.library.referencing.acceptance.authors;
+
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/package-info.java
+++ b/referencing/src/acceptance/java/org/adhuc/library/referencing/acceptance/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.adhuc.library.referencing.acceptance;
+
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/acceptance/resources/features/referencing-author.feature
+++ b/referencing/src/acceptance/resources/features/referencing-author.feature
@@ -3,13 +3,12 @@ Feature: Reference a new author
 
     Rule: Author can be referenced with minimal required information
 
-        @PendingFeature
         Scenario: Reference an author with its name and date of birth only
             Given Estelle is a librarian
             And Alain Damasio is not present in the list of authors
             When she references new author Alain Damasio born on 1969-08-01
             Then Alain Damasio is referenced
-            And Alain Damasio is present in the list of authors
+            And Alain Damasio is now present in the list of authors
 
         @PendingFeature
         Scenario: Reference an author with its surname and year of birth only
@@ -17,35 +16,32 @@ Feature: Reference a new author
             And Molière is not present in the list of authors
             When she references new author Molière born on 1622
             Then Molière is referenced
-            And Molière is present in the list of authors
+            And Molière is now present in the list of authors
 
-        @PendingFeature
         Scenario: Reference a dead author with its date of death
             Given Estelle is a librarian
             And Franz Kafka is not present in the list of authors
-            When she reference new author Franz Kafka born on 1883-07-03 and dead on 1924-06-03
+            When she references new author Franz Kafka born on 1883-07-03 and dead on 1924-06-03
             Then Franz Kafka is referenced
-            And Franz Kafka is present in the list of authors
+            And Franz Kafka is now present in the list of authors
 
     Rule: Author cannot be referenced with missing required information
 
-        @PendingFeature
         Scenario: Reference an author with only its name
             Given Estelle is a librarian
             And Alexandre Dumas is not present in the list of authors
             When she references new author Alexandre Dumas
             Then the referencing fails with date of birth required
-            And Alexandre Dumas is not present in the list of authors
+            And Alexandre Dumas is still not present in the list of authors
 
     Rule: Different authors can be referenced with same name and date of birth
     To avoid blocking author referencing in case of multiple authors with the same name, we allow author duplication.
     This means that a librarian should be proposed the list of existing authors with the same name so that she can
     decide whether she needs to reference a new author or this author is already referenced in the system.
 
-        @PendingFeature
         Scenario: Reference an author that already exists
             Given Estelle is a librarian
-            And George Orwell is present in the list of authors
-            When she reference new author George Orwell born on 1903-06-25 and dead on 1950-01-21
+            And George Orwell born on 1903-06-25 and dead on 1950-01-21 is present in the list of authors
+            When she references new author George Orwell born on 1903-06-25 and dead on 1950-01-21
             Then George Orwell is referenced
             And George Orwell is present twice in the list of authors

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/PaginationSerializationConfiguration.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/PaginationSerializationConfiguration.java
@@ -1,0 +1,32 @@
+package org.adhuc.library.referencing.adapter.rest;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.hateoas.PagedModel;
+
+import java.io.IOException;
+
+@Configuration
+public class PaginationSerializationConfiguration {
+    @Bean
+    public Jackson2ObjectMapperBuilderCustomizer jsonCustomizer() {
+        return builder -> builder.serializerByType(PagedModel.PageMetadata.class, new PageMetadataSerializer());
+    }
+
+    private static class PageMetadataSerializer extends JsonSerializer<PagedModel.PageMetadata> {
+        @Override
+        public void serialize(PagedModel.PageMetadata value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+            gen.writeFieldName("page");
+            gen.writeStartObject();
+            gen.writeNumberField("size", value.getSize());
+            gen.writeNumberField("total_elements", value.getTotalElements());
+            gen.writeNumberField("total_pages", value.getTotalPages());
+            gen.writeNumberField("number", value.getNumber());
+            gen.writeEndObject();
+        }
+    }
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/ProblemError.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/ProblemError.java
@@ -1,0 +1,40 @@
+package org.adhuc.library.referencing.adapter.rest;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A problem error, used to indicate the origin of the error in a validation problem. This can be used in combination
+ * with the {@link org.springframework.hateoas.mediatype.problem.Problem} class, as:
+ * <pre><code>
+ *     Problem.create()
+ *                 .withType(URI.create("/problems/some-problem"))
+ *                 .withStatus(BAD_REQUEST)
+ *                 .withTitle("Some problem")
+ *                 .withDetail("Problem details")
+ *                 .withProperties(map -> map.put("errors", List.of(new ParameterError("Error detail", "parameter_name"))));
+ * </code></pre>
+ */
+public sealed interface ProblemError permits ProblemError.ParameterError, ProblemError.PointerError {
+    /**
+     * A parameter error, that contains:
+     * <ul>
+     *     <li><b>{@code detail}</b> indicates why the error occurred</li>
+     *     <li><b>{@code parameter}</b> indicates which request parameter is the source of the error</li>
+     * </ul>
+     */
+    record ParameterError(String detail, @Nullable String parameter) implements ProblemError {
+
+    }
+
+    /**
+     * A pointer error, that contains:
+     * <ul>
+     *     <li><b>{@code detail}</b> indicates why the error occurred</li>
+     *     <li><b>{@code pointer}</b> indicates which part of the request body is the source of the error, based on
+     *     <a href="https://www.rfc-editor.org/rfc/rfc6901">a JSON pointer</a></li>
+     * </ul>
+     */
+    record PointerError(String detail, String pointer) implements ProblemError {
+
+    }
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorModel.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorModel.java
@@ -1,0 +1,28 @@
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import org.adhuc.library.referencing.authors.Author;
+import org.jspecify.annotations.Nullable;
+import org.springframework.hateoas.RepresentationModel;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility.ANY;
+
+@SuppressWarnings("FieldCanBeLocal")
+@JsonAutoDetect(fieldVisibility = ANY)
+public class AuthorModel extends RepresentationModel<AuthorModel> {
+    private final UUID id;
+    private final String name;
+    private final LocalDate dateOfBirth;
+    @Nullable
+    private final LocalDate dateOfDeath;
+
+    public AuthorModel(Author author) {
+        this.id = author.id();
+        this.name = author.name();
+        this.dateOfBirth = author.dateOfBirth();
+        this.dateOfDeath = author.dateOfDeath().orElse(null);
+    }
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorModelAssembler.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorModelAssembler.java
@@ -1,0 +1,30 @@
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import org.adhuc.library.referencing.authors.Author;
+import org.springframework.hateoas.server.mvc.RepresentationModelAssemblerSupport;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+
+@Component
+public class AuthorModelAssembler extends RepresentationModelAssemblerSupport<Author, AuthorModel> {
+    public AuthorModelAssembler() {
+        super(AuthorsController.class, AuthorModel.class);
+    }
+
+    @NonNull
+    @Override
+    public AuthorModel toModel(@NonNull Author author) {
+        var model = instantiateModel(author);
+        model.add(linkTo(methodOn(AuthorsController.class).getAuthor(author.id())).withSelfRel());
+        return model;
+    }
+
+    @NonNull
+    @Override
+    protected AuthorModel instantiateModel(@NonNull Author author) {
+        return new AuthorModel(author);
+    }
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorReferencingRequest.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorReferencingRequest.java
@@ -1,0 +1,8 @@
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+
+record AuthorReferencingRequest(String name, LocalDate dateOfBirth, @Nullable LocalDate dateOfDeath) {
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorsController.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorsController.java
@@ -1,0 +1,80 @@
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import org.adhuc.library.referencing.authors.Author;
+import org.adhuc.library.referencing.authors.AuthorsConsultationService;
+import org.adhuc.library.referencing.authors.AuthorsReferencingService;
+import org.adhuc.library.referencing.authors.ReferenceAuthor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.LinkRelation;
+import org.springframework.hateoas.mediatype.hal.HalModelBuilder;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Objects;
+import java.util.UUID;
+
+import static java.util.Objects.requireNonNull;
+import static org.springframework.hateoas.IanaLinkRelations.SELF;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON;
+import static org.springframework.hateoas.MediaTypes.HAL_JSON_VALUE;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.linkTo;
+import static org.springframework.hateoas.server.mvc.WebMvcLinkBuilder.methodOn;
+import static org.springframework.http.HttpStatus.*;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+@RestController
+@RequestMapping(path = "/api/v1/authors", produces = {APPLICATION_JSON_VALUE, HAL_JSON_VALUE})
+class AuthorsController {
+
+    private final PagedResourcesAssembler<Author> pageAssembler;
+    private final AuthorModelAssembler authorModelAssembler;
+    private final AuthorsConsultationService authorsConsultationService;
+    private final AuthorsReferencingService authorsReferencingService;
+
+    AuthorsController(PagedResourcesAssembler<Author> pageAssembler,
+                      AuthorModelAssembler authorModelAssembler,
+                      AuthorsConsultationService authorsConsultationService,
+                      AuthorsReferencingService authorsReferencingService) {
+        this.pageAssembler = pageAssembler;
+        this.authorModelAssembler = authorModelAssembler;
+        this.authorsConsultationService = authorsConsultationService;
+        this.authorsReferencingService = authorsReferencingService;
+    }
+
+    @GetMapping
+    ResponseEntity<Object> listAuthors(@RequestParam(required = false, defaultValue = "0") Integer page,
+                                       @RequestParam(required = false, defaultValue = "50") Integer size) {
+        var request = PageRequest.of(page, size);
+        var authorsPage = authorsConsultationService.getPage(request);
+        var response = pageAssembler.toModel(authorsPage, linkTo(methodOn(AuthorsController.class).listAuthors(page, size)).withSelfRel());
+
+        var responseBody = HalModelBuilder.halModelOf(requireNonNull(response.getMetadata()))
+                .links(response.getLinks());
+        if (!authorsPage.isEmpty()) {
+            var authors = authorModelAssembler.toCollectionModel(authorsPage).getContent();
+            responseBody = responseBody.embed(authors, LinkRelation.of("authors"));
+        }
+
+        return ResponseEntity.status(PARTIAL_CONTENT).body(responseBody.build());
+    }
+
+    @PostMapping
+    ResponseEntity<?> referenceAuthor(@RequestBody AuthorReferencingRequest request) {
+        var command = new ReferenceAuthor(request.name(), request.dateOfBirth(), request.dateOfDeath());
+        var author = Objects.requireNonNull(authorsReferencingService.referenceAuthor(command));
+
+        var model = authorModelAssembler.toModel(author);
+        return ResponseEntity.status(CREATED).contentType(HAL_JSON)
+                .location(URI.create(model.getLink(SELF).map(Link::getHref).orElseThrow()))
+                .body(model);
+    }
+
+    @GetMapping("/{id}")
+    ResponseEntity<?> getAuthor(@PathVariable UUID id) {
+        return ResponseEntity.status(NOT_IMPLEMENTED).build();
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/authors/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@InfrastructureRing
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@InfrastructureRing
+package org.adhuc.library.referencing.adapter.rest;
+
+import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/InvalidRequestBuilder.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/InvalidRequestBuilder.java
@@ -1,0 +1,22 @@
+package org.adhuc.library.referencing.adapter.rest.support.validation;
+
+import org.adhuc.library.referencing.adapter.rest.ProblemError;
+import org.springframework.hateoas.mediatype.problem.Problem;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public class InvalidRequestBuilder {
+
+    public static Problem invalidRequest(List<? extends ProblemError> errors) {
+        return Problem.create()
+                .withType(URI.create("/problems/invalid-request"))
+                .withStatus(BAD_REQUEST)
+                .withTitle("Request validation error")
+                .withDetail("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")
+                .withProperties(map -> map.put("errors", errors));
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/OpenApiRequestValidationExceptionHandler.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/OpenApiRequestValidationExceptionHandler.java
@@ -1,0 +1,58 @@
+package org.adhuc.library.referencing.adapter.rest.support.validation.openapi;
+
+import com.atlassian.oai.validator.report.ValidationReport;
+import com.atlassian.oai.validator.springmvc.InvalidRequestException;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.adhuc.library.referencing.adapter.rest.ProblemError;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+import static org.adhuc.library.referencing.adapter.rest.support.validation.InvalidRequestBuilder.invalidRequest;
+import static org.springframework.http.MediaType.APPLICATION_PROBLEM_JSON;
+
+@RestControllerAdvice
+public class OpenApiRequestValidationExceptionHandler {
+
+    @ExceptionHandler(InvalidRequestException.class)
+    ResponseEntity<Object> handleInvalidOpenApiRequest(InvalidRequestException e, WebRequest request) {
+        var problem = invalidRequest(extractErrors(e.getValidationReport().getMessages()));
+        return ResponseEntity.badRequest().contentType(APPLICATION_PROBLEM_JSON).body(problem);
+    }
+
+    private List<? extends ProblemError> extractErrors(List<ValidationReport.Message> messages) {
+        return messages.stream()
+                .flatMap(message -> extractError(message).stream())
+                .toList();
+    }
+
+    private Optional<ProblemError> extractError(ValidationReport.Message message) {
+        return message.getContext().flatMap(context -> mapParameterError(message.getMessage(), context)
+                .or(() -> mapPointerError(message.getMessage(), context))
+                .or(() -> Optional.of(mapGeneralError(message.getMessage())))
+        );
+    }
+
+    private Optional<ProblemError> mapParameterError(String message, ValidationReport.MessageContext context) {
+        return context.getParameter().map(Parameter::getName)
+                .map(parameter -> new ProblemError.ParameterError(message, parameter));
+    }
+
+    private Optional<ProblemError> mapPointerError(String message, ValidationReport.MessageContext context) {
+        var matcher = Pattern.compile("^Object has missing required properties \\(\\[\"(.*)\"]\\)$").matcher(message);
+        if (matcher.matches()) {
+            return Optional.of(new ProblemError.PointerError("Missing required property", matcher.group(1)));
+        }
+        return Optional.empty();
+    }
+
+    private ProblemError mapGeneralError(String message) {
+        return new ProblemError.ParameterError(message, null);
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/RequestValidationConfiguration.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/RequestValidationConfiguration.java
@@ -1,0 +1,95 @@
+package org.adhuc.library.referencing.adapter.rest.support.validation.openapi;
+
+import com.atlassian.oai.validator.OpenApiInteractionValidator;
+import com.atlassian.oai.validator.report.LevelResolverFactory;
+import com.atlassian.oai.validator.springmvc.OpenApiValidationFilter;
+import com.atlassian.oai.validator.springmvc.OpenApiValidationInterceptor;
+import com.atlassian.oai.validator.whitelist.ValidationErrorsWhitelist;
+import com.atlassian.oai.validator.whitelist.rule.WhitelistRule;
+import io.micrometer.core.instrument.util.IOUtils;
+import jakarta.servlet.Filter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static com.atlassian.oai.validator.report.ValidationReport.Level.ERROR;
+import static com.atlassian.oai.validator.whitelist.rule.WhitelistRules.anyOf;
+
+@Configuration
+public class RequestValidationConfiguration {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestValidationConfiguration.class);
+
+    @Bean
+    Resource openApiSpecification(ResourceLoader resourceLoader) {
+        return resourceLoader.getResource("classpath:api/openapi.yml");
+    }
+
+    @Configuration
+    static class OpenApiValidationConfigurer implements WebMvcConfigurer {
+
+        private static final String API_BASE_PATH = "/api";
+
+        private final OpenApiValidationInterceptor validationInterceptor;
+
+        OpenApiValidationConfigurer(@Qualifier("openApiSpecification") Resource apiSpecificationResource,
+                                    @Value("${management.endpoints.web.base-path}") String managementBasePath) throws IOException {
+            LOGGER.info("Initialize OpenApi validation configuration based on {} specification and ignoring management endpoints from base path {}",
+                    apiSpecificationResource, managementBasePath);
+            var apiSpecification = IOUtils.toString(apiSpecificationResource.getInputStream(), Charset.defaultCharset());
+            this.validationInterceptor = new OpenApiValidationInterceptor(
+                    OpenApiInteractionValidator.createForInlineApiSpecification(apiSpecification)
+                            .withLevelResolver(LevelResolverFactory.withAdditionalPropertiesIgnored())
+                            .withBasePathOverride(API_BASE_PATH)
+                            .withWhitelist(validationErrorsWhitelist(managementBasePath))
+                            .build());
+        }
+
+        private ValidationErrorsWhitelist validationErrorsWhitelist(String managementBasePath) {
+            LOGGER.info("Activate OpenAPI whitelist for OpenAPI specification documentation");
+            var openApiDocPaths = List.of("/swagger-ui/", "/openapi.yml", "/api/doc/");
+            return ValidationErrorsWhitelist.create()
+                    .withRule(
+                            "Ignore OpenAPI specification documentation",
+                            anyOf(
+                                    requestPathStartsWith(openApiDocPaths),
+                                    responseInErrorWithMessageAboutPath(openApiDocPaths)
+                            )
+                    );
+        }
+
+        private WhitelistRule requestPathStartsWith(final List<String> pathPrefixes) {
+            return (message, operation, request, response) ->
+                    request != null && pathPrefixes.stream().anyMatch(prefix -> request.getPath().startsWith(prefix));
+        }
+
+        private WhitelistRule responseInErrorWithMessageAboutPath(List<String> pathPrefixes) {
+            return (message, operation, request, response) ->
+                    response != null && message.getLevel().equals(ERROR) && message.getMessage().contains("No API path found that matches request")
+                            && pathPrefixes.stream().anyMatch(prefix -> message.getMessage().contains(prefix));
+        }
+
+        @Override
+        public void addInterceptors(final InterceptorRegistry registry) {
+            registry.addInterceptor(validationInterceptor);
+        }
+
+        @Bean
+        Filter validationFilter() {
+            return new OpenApiValidationFilter(true, true);
+        }
+
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/openapi/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@InfrastructureRing
+package org.adhuc.library.referencing.adapter.rest.support.validation.openapi;
+
+import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/adapter/rest/support/validation/package-info.java
@@ -1,0 +1,6 @@
+@NullMarked
+@InfrastructureRing
+package org.adhuc.library.referencing.adapter.rest.support.validation;
+
+import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/Author.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/Author.java
@@ -1,0 +1,68 @@
+package org.adhuc.library.referencing.authors;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+public class Author {
+
+    private final UUID id;
+    private final String name;
+    private final LocalDate dateOfBirth;
+    @Nullable
+    private final LocalDate dateOfDeath;
+
+    public Author(UUID id, String name, LocalDate dateOfBirth) {
+        this(id, name, dateOfBirth, null);
+    }
+
+    public Author(UUID id, String name, LocalDate dateOfBirth, @Nullable LocalDate dateOfDeath) {
+        this.id = id;
+        this.name = name;
+        this.dateOfBirth = dateOfBirth;
+        this.dateOfDeath = dateOfDeath;
+    }
+
+    public UUID id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public LocalDate dateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public Optional<LocalDate> dateOfDeath() {
+        return Optional.ofNullable(dateOfDeath);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Author author = (Author) o;
+        return Objects.equals(id, author.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+
+    @Override
+    public String toString() {
+        return "Author(" +
+                "id=" + id +
+                ", name='" + name + '\'' +
+                ", dateOfBirth=" + dateOfBirth +
+                ", dateOfDeath=" + dateOfDeath +
+                ')';
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsConsultationService.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsConsultationService.java
@@ -1,0 +1,22 @@
+package org.adhuc.library.referencing.authors;
+
+import org.jmolecules.architecture.onion.classical.ApplicationServiceRing;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@ApplicationServiceRing
+public class AuthorsConsultationService {
+
+    private final AuthorsRepository authorsRepository;
+
+    public AuthorsConsultationService(AuthorsRepository authorsRepository) {
+        this.authorsRepository = authorsRepository;
+    }
+
+    public Page<Author> getPage(Pageable request) {
+        return authorsRepository.findPage(request);
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsReferencingService.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsReferencingService.java
@@ -1,0 +1,24 @@
+package org.adhuc.library.referencing.authors;
+
+import org.jmolecules.architecture.onion.classical.ApplicationServiceRing;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+@ApplicationServiceRing
+public class AuthorsReferencingService {
+
+    private final AuthorsRepository authorsRepository;
+
+    public AuthorsReferencingService(AuthorsRepository authorsRepository) {
+        this.authorsRepository = authorsRepository;
+    }
+
+    public Author referenceAuthor(ReferenceAuthor command) {
+        var author = new Author(UUID.randomUUID(), command.name(), command.dateOfBirth(), command.dateOfDeath().orElse(null));
+        authorsRepository.save(author);
+        return author;
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsRepository.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/AuthorsRepository.java
@@ -1,0 +1,12 @@
+package org.adhuc.library.referencing.authors;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface AuthorsRepository {
+
+    Page<Author> findPage(Pageable request);
+
+    void save(Author author);
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/ReferenceAuthor.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/ReferenceAuthor.java
@@ -1,0 +1,37 @@
+package org.adhuc.library.referencing.authors;
+
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+public class ReferenceAuthor {
+
+    private final String name;
+    private final LocalDate dateOfBirth;
+    @Nullable
+    private final LocalDate dateOfDeath;
+
+    public ReferenceAuthor(String name, LocalDate dateOfBirth) {
+        this(name, dateOfBirth, null);
+    }
+
+    public ReferenceAuthor(String name, LocalDate dateOfBirth, @Nullable LocalDate dateOfDeath) {
+        this.name = name;
+        this.dateOfBirth = dateOfBirth;
+        this.dateOfDeath = dateOfDeath;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public LocalDate dateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public Optional<LocalDate> dateOfDeath() {
+        return Optional.ofNullable(dateOfDeath);
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/internal/InMemoryAuthorsRepository.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/internal/InMemoryAuthorsRepository.java
@@ -1,0 +1,41 @@
+package org.adhuc.library.referencing.authors.internal;
+
+import org.adhuc.library.referencing.authors.Author;
+import org.adhuc.library.referencing.authors.AuthorsRepository;
+import org.jmolecules.architecture.onion.classical.InfrastructureRing;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.*;
+
+@Repository
+@InfrastructureRing
+public class InMemoryAuthorsRepository implements AuthorsRepository {
+
+    private final Map<UUID, Author> authors = new HashMap<>();
+
+    @Override
+    public Page<Author> findPage(Pageable request) {
+        var pageAuthors = authors.values().stream()
+                .skip(request.getOffset())
+                .limit(request.getPageSize())
+                .toList();
+        return new PageImpl<>(pageAuthors, request, authors.size());
+    }
+
+    public Optional<Author> findById(UUID id) {
+        return Optional.ofNullable(authors.get(id));
+    }
+
+    @Override
+    public void save(Author author) {
+        authors.put(author.id(), author);
+    }
+
+    public void saveAll(Collection<Author> authors) {
+        authors.forEach(author -> this.authors.put(author.id(), author));
+    }
+
+}

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/internal/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/internal/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.adhuc.library.referencing.authors.internal;
+
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/java/org/adhuc/library/referencing/authors/package-info.java
+++ b/referencing/src/main/java/org/adhuc/library/referencing/authors/package-info.java
@@ -1,0 +1,7 @@
+@NullMarked
+// By default, all classes are domain model
+@DomainModelRing
+package org.adhuc.library.referencing.authors;
+
+import org.jmolecules.architecture.onion.classical.DomainModelRing;
+import org.jspecify.annotations.NullMarked;

--- a/referencing/src/main/resources/api/openapi.yml
+++ b/referencing/src/main/resources/api/openapi.yml
@@ -1,0 +1,523 @@
+openapi: 3.0.3
+info:
+  title: Library Referencing
+  description: Provides an API to reference authors, books and editions.
+  contact:
+    email: acarbenay@adhuc.fr
+  version: 1.0.0
+servers:
+  - url: https://localhost:8080/api
+    description: Local environment
+  - url: https://referencing.library.adhuc.org/api
+    description: Production environment (coming soon)
+tags:
+  - name: Authors
+    description: Manage referencing of authors within the library.
+paths:
+  /v1/authors:
+    get:
+      tags:
+        - Authors
+      summary: Gets a paginated list of authors based on filters.
+      description: |
+        The authors list can be sorted and filtered in many different ways.
+      operationId: getAuthors
+      parameters:
+        - $ref: '#/components/parameters/Page'
+        - $ref: '#/components/parameters/PageSize'
+      responses:
+        '206':
+          $ref: '#/components/responses/Authors'
+        '400':
+          $ref: '#/components/responses/InvalidAuthorsParameters'
+        '500':
+          $ref: '#/components/responses/GeneralError'
+    post:
+      tags:
+        - Authors
+      summary: References a new author.
+      description: |
+        References an author to be able to reference books and editions.
+      operationId: referenceAuthor
+      requestBody:
+        $ref: '#/components/requestBodies/ReferenceAuthor'
+      responses:
+        '201':
+          $ref: '#/components/responses/ReferencedAuthor'
+        '400':
+          $ref: '#/components/responses/InvalidAuthorReferencing'
+        '401':
+          $ref: '#/components/responses/UnauthorizedError'
+        '403':
+          $ref: '#/components/responses/ForbiddenError'
+        '500':
+          $ref: '#/components/responses/GeneralError'
+  /v1/authors/{id}:
+    get:
+      tags:
+        - Authors
+      summary: Gets the details of an author based on its identity.
+      description: |
+        The details of an author contain all its information.
+      operationId: getAuthor
+      parameters:
+        - $ref: '#/components/parameters/AuthorId'
+      responses:
+        '200':
+          $ref: '#/components/responses/Author'
+        '400':
+          $ref: '#/components/responses/InvalidAuthorId'
+        '404':
+          $ref: '#/components/responses/UnknownAuthor'
+        '500':
+          $ref: '#/components/responses/GeneralError'
+components:
+  parameters:
+    AuthorId:
+      name: id
+      description: Author identity.
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+        example: 83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725
+    Page:
+      name: page
+      description: |
+        Page number to retrieve from the collection, starting from 0. This
+        parameter must be used in combination with the *size* parameter to
+        specify the number of elements in a page.
+      in: query
+      required: false
+      schema:
+        type: number
+        minimum: 0
+        default: 0
+        example: 1
+    PageSize:
+      name: size
+      description: |
+        Size of the page to retrieve from the collection. This parameter must be
+        used in combination with the *page* parameter to specify the current page.
+      in: query
+      required: false
+      schema:
+        type: number
+        minimum: 1
+        default: 50
+        example: 50
+  requestBodies:
+    ReferenceAuthor:
+      required: true
+      description: A command to reference an author.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ReferenceAuthor'
+        application/hal+json:
+          schema:
+            $ref: '#/components/schemas/ReferenceAuthor'
+  responses:
+    Authors:
+      description: The referenced authors.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Authors'
+        application/hal+json:
+          schema:
+            $ref: '#/components/schemas/Authors'
+    ReferencedAuthor:
+      description: The referenced author.
+      headers:
+        Location:
+          description: Link the referenced author.
+          schema:
+            type: string
+            example: 'https://referencing.library.adhuc.org/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Author'
+        application/hal+json:
+          schema:
+            $ref: '#/components/schemas/Author'
+    InvalidAuthorReferencing:
+      description: Invalid author referencing command.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            invalidAuthorReferencing:
+              $ref: '#/components/examples/InvalidAuthorReferencing'
+    InvalidAuthorsParameters:
+      description: Invalid pagination parameters.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            pageNumber:
+              $ref: '#/components/examples/InvalidPageNumber'
+            pageSize:
+              $ref: '#/components/examples/InvalidPageSize'
+    Author:
+      description: A referenced author.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Author'
+        application/hal+json:
+          schema:
+            $ref: '#/components/schemas/Author'
+    InvalidAuthorId:
+      description: Invalid author ID.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            invalidId:
+              $ref: '#/components/examples/InvalidUUIDId'
+    UnknownAuthor:
+      description: No author corresponds to the specified identity.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            unknown:
+              $ref: '#/components/examples/UnknownAuthor'
+    UnauthorizedError:
+      description: Unauthorized error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            unauthorized:
+              $ref: '#/components/examples/UnauthorizedError'
+    ForbiddenError:
+      description: Forbidden error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            unauthorized:
+              $ref: '#/components/examples/ForbiddenError'
+    GeneralError:
+      description: General unexpected error.
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/Problem'
+          examples:
+            general:
+              $ref: '#/components/examples/GeneralError'
+  headers:
+    ContentLanguage:
+      schema:
+        type: string
+      description: |
+        The language of the localized resource, ideally corresponding to one of
+        those provided in the `Accept-Language` header.
+
+        See [documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Content-Language)
+        for more information about this header.
+  schemas:
+    Authors:
+      type: object
+      required:
+        - page
+        - '_links'
+      properties:
+        page:
+          $ref: '#/components/schemas/Page'
+        '_embedded':
+          type: object
+          readOnly: true
+          required:
+            - authors
+          properties:
+            authors:
+              description: |
+                The authors collection, containing basic information for each
+                author.
+              type: array
+              items:
+                $ref: '#/components/schemas/Author'
+        '_links':
+          type: object
+          readOnly: true
+          required:
+            - self
+          properties:
+            self:
+              description: Link to this authors page.
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors?page=1&size=50'
+            template:
+              description: Link to the template of authors page.
+              type: object
+              required:
+                - href
+                - templated
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors{?page,size}'
+                templated:
+                  type: boolean
+                  enum:
+                    - true
+            prev:
+              description: Link to the previous authors page.
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors?page=0&size=50'
+            next:
+              description: Link to the next authors page.
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors?page=3&size=50'
+            first:
+              description: Link to the first authors page.
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors?page=0&size=50'
+            last:
+              description: Link to the last authors page.
+              type: object
+              required:
+                - href
+              properties:
+                href:
+                  type: string
+                  example: 'https://referencing.library.adhuc.org/api/v1/authors?page=8&size=50'
+    Author:
+      type: object
+      required:
+        - id
+        - name
+        - date_of_birth
+        - '_links'
+      properties:
+        id:
+          $ref: '#/components/schemas/AuthorId'
+        name:
+          $ref: '#/components/schemas/AuthorName'
+        date_of_birth:
+          $ref: '#/components/schemas/DateOfBirth'
+        date_of_death:
+          $ref: '#/components/schemas/DateOfDeath'
+        '_links':
+          type: object
+          readOnly: true
+          required:
+            - self
+          properties:
+            self:
+              $ref: '#/components/schemas/AuthorLink'
+    AuthorId:
+      type: string
+      format: uuid
+      example: 83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725
+    AuthorLink:
+      type: object
+      description: Link to the author. Can be used to see the detail of the author.
+      required:
+        - href
+      properties:
+        href:
+          type: string
+          example: 'https://referencing.library.adhuc.org/api/v1/authors/83b5bf5d-b8bc-4ea7-82dd-51d7bd1af725'
+    AuthorName:
+      type: string
+      example: Jean-Jacques Rousseau
+    DateOfBirth:
+      type: string
+      format: date
+      example: 1712-06-28
+    DateOfDeath:
+      type: string
+      format: date
+      example: 1778-07-02
+    ReferenceAuthor:
+      type: object
+      required:
+        - name
+        - date_of_birth
+      properties:
+        name:
+          $ref: '#/components/schemas/AuthorName'
+        date_of_birth:
+          $ref: '#/components/schemas/DateOfBirth'
+        date_of_death:
+          $ref: '#/components/schemas/DateOfDeath'
+    Page:
+      type: object
+      readOnly: true
+      required:
+        - size
+        - total_elements
+        - total_pages
+        - number
+      properties:
+        size:
+          description: The requested page size. The number of elements in the current page is between 0 and this size.
+          type: number
+          example: 50
+          minimum: 0
+        total_elements:
+          description: The number of elements in all pages.
+          type: number
+          example: 443
+          minimum: 0
+        total_pages:
+          description: The number of pages containing all the elements.
+          type: number
+          example: 9
+          minimum: 0
+        number:
+          description: The current page, starting at 0.
+          type: number
+          example: 1
+          minimum: 0
+    Problem:
+      type: object
+      required:
+        - type
+        - status
+        - title
+        - detail
+      properties:
+        type:
+          type: string
+          format: uri-reference
+          description: The problem type.
+        status:
+          type: integer
+          description: The HTTP status of the response.
+        title:
+          type: string
+          description: A human-readable summary of the problem type.
+        detail:
+          type: string
+          description: A human-readable explanation specific to this occurrence of the problem.
+        errors:
+          type: array
+          description: An extension to the problem, providing information about each error.
+          items:
+            oneOf:
+              - type: object
+                required:
+                  - detail
+                  - pointer
+                properties:
+                  detail:
+                    type: string
+                    description: The error detail used to determine why the server returned an error.
+                  pointer:
+                    type: string
+                    description: |
+                      A JSON pointer (https://datatracker.ietf.org/doc/html/rfc6901) to the associated entity in the request
+                      document (e.g. "/" for a primary object, "/name" for a specific attribute named "name").
+              - type: object
+                required:
+                  - detail
+                  - parameter
+                properties:
+                  detail:
+                    type: string
+                    description: The error detail used to determine why the server returned an error.
+                  parameter:
+                    type: string
+                    description: A string indicating which URI query parameter caused the error.
+  examples:
+    InvalidPageNumber:
+      value:
+        type: /problems/invalid-request
+        status: 400
+        title: Request validation error
+        detail: Invalid page number
+        errors:
+          - detail: 'Numeric instance is lower than the required minimum (minimum: 0, found: -1)'
+            parameter: page
+      summary: Invalid page number.
+    InvalidPageSize:
+      value:
+        type: /problems/invalid-request
+        status: 400
+        title: Request validation error
+        detail: Invalid page size
+        errors:
+          - detail: 'Numeric instance is lower than the required minimum (minimum: 1, found: 0)'
+            parameter: size
+      summary: Invalid page size.
+    InvalidAuthorReferencing:
+      value:
+        type: /problems/invalid-request
+        status: 400
+        title: Request validation error
+        detail: Invalid author referencing command
+        errors:
+          - detail: 'Empty string'
+            parameter: name
+    InvalidUUIDId:
+      value:
+        type: /problems/invalid-request
+        status: 400
+        title: Request validation error
+        detail: Invalid UUID id
+        errors:
+          - detail: 'Input string "1234" is not a valid UUID'
+            parameter: id
+      summary: Invalid UUID passed as id in the path.
+    UnknownAuthor:
+      value:
+        type: /problems/unknown-entity
+        status: 404
+        title: Unknown author
+        detail: No author exists with id '96c7774f-dd6b-43d4-bd0e-6a7d1aad09a4'
+      summary: Error when no author corresponds to the specified identity.
+    UnauthorizedError:
+      value:
+        type: /problems/unauthorized
+        status: 401
+        title: Unauthorized access
+        detail: Action requires authorization
+      summary: Unauthorized access.
+    ForbiddenError:
+      value:
+        type: /problems/forbidden
+        status: 403
+        title: Forbidden access
+        detail: Action requires appropriate access rights
+      summary: Forbidden access.
+    GeneralError:
+      value:
+        type: /problems/general-error
+        status: 500
+        title: General error
+        detail: Unexpected error
+      summary: Unexpected error.

--- a/referencing/src/main/resources/application.yml
+++ b/referencing/src/main/resources/application.yml
@@ -5,6 +5,7 @@ spring:
     name: catalog
   jackson:
     property-naming-strategy: SNAKE_CASE
+    default-property-inclusion: NON_ABSENT
 
 management:
   endpoints:

--- a/referencing/src/main/resources/static/openapi.yml
+++ b/referencing/src/main/resources/static/openapi.yml
@@ -1,0 +1,1 @@
+../api/openapi.yml

--- a/referencing/src/test/java/org/adhuc/library/referencing/ModulesTests.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/ModulesTests.java
@@ -1,0 +1,23 @@
+package org.adhuc.library.referencing;
+
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.springframework.modulith.core.ApplicationModules;
+import org.springframework.modulith.docs.Documenter;
+
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAPackage;
+
+@Tag("integration")
+class ModulesTests {
+
+    private static final String ADAPTERS = "..library.referencing.adapter..";
+
+    @Test
+    void writeDocumentationSnippets() {
+        var modules = ApplicationModules.of(Application.class, resideInAPackage(ADAPTERS)).verify();
+
+        modules.forEach(System.out::println);
+        new Documenter(modules).writeDocumentation();
+    }
+
+}

--- a/referencing/src/test/java/org/adhuc/library/referencing/adapter/rest/OpenApiValidationTests.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/adapter/rest/OpenApiValidationTests.java
@@ -1,0 +1,61 @@
+package org.adhuc.library.referencing.adapter.rest;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SuppressWarnings({"unused", "NotNullFieldNotInitialized"})
+@Tag("integration")
+@Tag("restApi")
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "management.endpoints.web.base-path=/management-custom"
+})
+@DisplayName("Open API validation should")
+class OpenApiValidationTests {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/health",
+            "/info",
+            "/beans"
+    })
+    @DisplayName("ignore management paths")
+    void managementPaths(String path) throws Exception {
+        mvc.perform(get("/management-custom" + path))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("not allow accessing path not specified in openapi endpoints")
+    void unknownPath() throws Exception {
+        mvc.perform(get("/api/v1/unknown"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "application/json",
+            "application/hal+json"
+    })
+    @DisplayName("allow accessing path specified in openapi endpoints")
+    void knownPath(String acceptHeader) throws Exception {
+        mvc.perform(get("/api/v1/authors").accept(acceptHeader))
+                .andExpect(status().is2xxSuccessful());
+    }
+
+}

--- a/referencing/src/test/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorsControllerTests.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/adapter/rest/authors/AuthorsControllerTests.java
@@ -1,0 +1,452 @@
+package org.adhuc.library.referencing.adapter.rest.authors;
+
+import net.datafaker.Faker;
+import org.adhuc.library.referencing.adapter.rest.PaginationSerializationConfiguration;
+import org.adhuc.library.referencing.adapter.rest.support.validation.openapi.RequestValidationConfiguration;
+import org.adhuc.library.referencing.authors.Author;
+import org.adhuc.library.referencing.authors.AuthorsConsultationService;
+import org.adhuc.library.referencing.authors.AuthorsMother.Authors;
+import org.adhuc.library.referencing.authors.AuthorsReferencingService;
+import org.adhuc.library.referencing.authors.ReferenceAuthor;
+import org.assertj.core.api.SoftAssertions;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static org.adhuc.library.referencing.authors.AuthorsMother.authors;
+import static org.adhuc.library.referencing.authors.AuthorsMother.builder;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SuppressWarnings({"NotNullFieldNotInitialized", "preview", "StringTemplateMigration"})
+@Tag("integration")
+@Tag("restApi")
+@WebMvcTest(controllers = {AuthorsController.class, AuthorModelAssembler.class})
+@Import({RequestValidationConfiguration.class, PaginationSerializationConfiguration.class})
+@DisplayName("Authors controller should")
+class AuthorsControllerTests {
+
+    private static final Faker FAKER = new Faker();
+
+    @Autowired
+    private MockMvc mvc;
+    @MockitoBean
+    private AuthorsConsultationService authorsConsultationService;
+    @MockitoBean
+    private AuthorsReferencingService authorsReferencingService;
+    private final ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.captor();
+    private final ArgumentCaptor<ReferenceAuthor> referenceCommandCaptor = ArgumentCaptor.captor();
+
+    @Test
+    @DisplayName("provide an empty page when no author has been referenced")
+    void listAuthorsEmptyDefaultPage() throws Exception {
+        var request = PageRequest.of(0, 50);
+        when(authorsConsultationService.getPage(any())).thenReturn(Page.empty(request));
+
+        mvc.perform(get("/api/v1/authors").accept("application/hal+json"))
+                .andExpect(status().isPartialContent())
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("page.size", equalTo(50)))
+                .andExpect(jsonPath("page.total_elements", equalTo(0)))
+                .andExpect(jsonPath("page.total_pages", equalTo(0)))
+                .andExpect(jsonPath("page.number", equalTo(0)))
+                .andExpect(jsonPath("_links.self.href", equalTo("http://localhost/api/v1/authors?page=0&size=50")))
+                .andExpect(jsonPath("_links.first").doesNotExist())
+                .andExpect(jsonPath("_links.prev").doesNotExist())
+                .andExpect(jsonPath("_links.next").doesNotExist())
+                .andExpect(jsonPath("_links.last").doesNotExist())
+                .andExpect(jsonPath("_embedded").doesNotExist());
+
+        verify(authorsConsultationService).getPage(pageableCaptor.capture());
+        var actual = pageableCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.getPageNumber()).isZero();
+            s.assertThat(actual.getPageSize()).isEqualTo(50);
+        });
+    }
+
+    @Test
+    @DisplayName("provide a unique page when the number of authors is lower than or equal to the requested page size")
+    void uniqueDefaultPage() throws Exception {
+        var numberOfElements = FAKER.random().nextInt(1, 50);
+        var authors = authors(numberOfElements);
+
+        var request = PageRequest.of(0, 50);
+        when(authorsConsultationService.getPage(any())).thenReturn(new PageImpl<>(authors, request, numberOfElements));
+
+        var result = mvc.perform(get("/api/v1/authors").accept("application/hal+json"))
+                .andDo(print())
+                .andExpect(status().isPartialContent())
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("page.size", equalTo(50)))
+                .andExpect(jsonPath("page.total_elements", equalTo(numberOfElements)))
+                .andExpect(jsonPath("page.total_pages", equalTo(1)))
+                .andExpect(jsonPath("page.number", equalTo(0)))
+                .andExpect(jsonPath("_links.self.href", equalTo("http://localhost/api/v1/authors?page=0&size=50")))
+                .andExpect(jsonPath("_links.first.href").doesNotExist())
+                .andExpect(jsonPath("_links.prev").doesNotExist())
+                .andExpect(jsonPath("_links.next").doesNotExist())
+                .andExpect(jsonPath("_links.last.href").doesNotExist())
+                .andExpect(jsonPath("_embedded").exists());
+
+        assertResponseContainsAllAuthors(result, authors);
+
+        verify(authorsConsultationService).getPage(pageableCaptor.capture());
+        var actual = pageableCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.getPageNumber()).isZero();
+            s.assertThat(actual.getPageSize()).isEqualTo(50);
+        });
+    }
+
+    @Test
+    @DisplayName("provide a page with default page size when not specified explicitly")
+    void defaultPageSize() throws Exception {
+        var pageIndex = FAKER.random().nextInt(1, 100);
+        var authors = pageSample(pageIndex, 50);
+
+        when(authorsConsultationService.getPage(any())).thenReturn(authors);
+
+        var result = mvc.perform(get("/api/v1/authors")
+                        .accept("application/hal+json")
+                        .queryParam("page", String.valueOf(authors.getNumber())))
+                .andExpect(status().isPartialContent())
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("page.size", equalTo(authors.getSize())))
+                .andExpect(jsonPath("page.total_elements", equalTo(Long.valueOf(authors.getTotalElements()).intValue())))
+                .andExpect(jsonPath("page.total_pages", equalTo(authors.getTotalPages())))
+                .andExpect(jsonPath("page.number", equalTo(authors.getNumber())))
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/authors?page=\{authors.getNumber()}&size=50")))
+                .andExpect(jsonPath("_embedded").exists());
+
+        assertResponseContainsAllAuthors(result, authors.toList());
+
+        verify(authorsConsultationService).getPage(pageableCaptor.capture());
+        var actual = pageableCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.getPageNumber()).isEqualTo(authors.getNumber());
+            s.assertThat(actual.getPageSize()).isEqualTo(50);
+        });
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-50", "-2", "-1"})
+    @DisplayName("refuse providing a page with a negative page number")
+    void getInvalidPageNumber(String pageNumber) throws Exception {
+        mvc.perform(get("/api/v1/authors").accept("application/hal+json")
+                        .queryParam("page", pageNumber)
+                ).andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("type", equalTo("/problems/invalid-request")))
+                .andExpect(jsonPath("status", equalTo(400)))
+                .andExpect(jsonPath("title", equalTo("Request validation error")))
+                .andExpect(jsonPath("detail", equalTo("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")))
+                .andExpect(jsonPath("errors").isArray())
+                .andExpect(jsonPath("errors", hasSize(1)))
+                .andExpect(jsonPath("errors[0].detail", equalTo(STR."Numeric instance is lower than the required minimum (minimum: 0, found: \{pageNumber})")))
+                .andExpect(jsonPath("errors[0].parameter", equalTo("page")));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"-50", "-1", "0"})
+    @DisplayName("refuse providing a page with a negative page size")
+    void getInvalidPageSize(String pageSize) throws Exception {
+        mvc.perform(get("/api/v1/authors").accept("application/hal+json")
+                        .queryParam("size", pageSize)
+                ).andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("type", equalTo("/problems/invalid-request")))
+                .andExpect(jsonPath("status", equalTo(400)))
+                .andExpect(jsonPath("title", equalTo("Request validation error")))
+                .andExpect(jsonPath("detail", equalTo("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")))
+                .andExpect(jsonPath("errors").isArray())
+                .andExpect(jsonPath("errors", hasSize(1)))
+                .andExpect(jsonPath("errors[0].detail",
+                        equalTo(STR."Numeric instance is lower than the required minimum (minimum: 1, found: \{pageSize})")))
+                .andExpect(jsonPath("errors[0].parameter", equalTo("size")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"-50,-1", "-2,-50", "-1,0"})
+    @DisplayName("refuse providing a page with a negative page number")
+    void getInvalidPageNumberAndSize(String pageNumber, String pageSize) throws Exception {
+        mvc.perform(get("/api/v1/authors").accept("application/hal+json")
+                        .queryParam("page", pageNumber)
+                        .queryParam("size", pageSize)
+                ).andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("type", equalTo("/problems/invalid-request")))
+                .andExpect(jsonPath("status", equalTo(400)))
+                .andExpect(jsonPath("title", equalTo("Request validation error")))
+                .andExpect(jsonPath("detail", equalTo("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")))
+                .andExpect(jsonPath("errors").isArray())
+                .andExpect(jsonPath("errors", hasSize(2)))
+                .andExpect(jsonPath("errors[0].detail",
+                        equalTo(STR."Numeric instance is lower than the required minimum (minimum: 0, found: \{pageNumber})")))
+                .andExpect(jsonPath("errors[0].parameter", equalTo("page")))
+                .andExpect(jsonPath("errors[1].detail",
+                        equalTo(STR."Numeric instance is lower than the required minimum (minimum: 1, found: \{pageSize})")))
+                .andExpect(jsonPath("errors[1].parameter", equalTo("size")));
+    }
+
+    @Test
+    @DisplayName("provide a page corresponding to requested page and size")
+    void getPage() throws Exception {
+        var pageIndex = FAKER.random().nextInt(0, 100);
+        var pageSize = FAKER.random().nextInt(2, 100);
+        var authors = pageSample(pageIndex, pageSize);
+
+        when(authorsConsultationService.getPage(any())).thenReturn(authors);
+
+        var result = mvc.perform(get("/api/v1/authors")
+                        .accept("application/hal+json")
+                        .queryParam("page", Integer.toString(pageIndex))
+                        .queryParam("size", Integer.toString(pageSize))
+                ).andExpect(status().isPartialContent())
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("page.size", equalTo(authors.getSize())))
+                .andExpect(jsonPath("page.total_elements", equalTo(Long.valueOf(authors.getTotalElements()).intValue())))
+                .andExpect(jsonPath("page.total_pages", equalTo(authors.getTotalPages())))
+                .andExpect(jsonPath("page.number", equalTo(pageIndex)))
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/authors?page=\{pageIndex}&size=\{pageSize}")))
+                .andExpect(jsonPath("_embedded").exists());
+
+        assertResponseContainsAllAuthors(result, authors.toList());
+
+        verify(authorsConsultationService).getPage(pageableCaptor.capture());
+        var actual = pageableCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.getPageNumber()).isEqualTo(authors.getNumber());
+            s.assertThat(actual.getPageSize()).isEqualTo(authors.getSize());
+        });
+    }
+
+    @ParameterizedTest(name = "[{index}] Page = {0}, size = {1}, first = {3}, prev = {4}, next = {5}, last = {6}")
+    @MethodSource({"uniquePagesProvider", "firstPagesProvider", "intermediatePagesProvider", "lastPagesProvider"})
+    @DisplayName("provide a page with navigation links")
+    void getPageWithNavigation(int pageIndex, int pageSize, Page<Author> authors, boolean hasFirst, boolean hasPrev,
+                               boolean hasNext, boolean hasLast) throws Exception {
+        when(authorsConsultationService.getPage(any())).thenReturn(authors);
+
+        var result = mvc.perform(get("/api/v1/authors")
+                        .accept("application/hal+json")
+                        .queryParam("page", Integer.toString(pageIndex))
+                        .queryParam("size", Integer.toString(pageSize))
+                ).andExpect(status().isPartialContent())
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/authors?page=\{pageIndex}&size=\{pageSize}")));
+
+        verifyNavigationLink(result, hasFirst, "first", STR."http://localhost/api/v1/authors?page=0&size=\{pageSize}");
+        verifyNavigationLink(result, hasPrev, "prev", STR."http://localhost/api/v1/authors?page=\{pageIndex - 1}&size=\{pageSize}");
+        verifyNavigationLink(result, hasNext, "next", STR."http://localhost/api/v1/authors?page=\{pageIndex + 1}&size=\{pageSize}");
+        verifyNavigationLink(result, hasLast, "last", STR."http://localhost/api/v1/authors?page=\{authors.getTotalPages() - 1}&size=\{pageSize}");
+    }
+
+    static void verifyNavigationLink(ResultActions result, boolean hasLink, String linkName, @Nullable String valueIfExists) throws Exception {
+        if (hasLink) {
+            result.andExpect(jsonPath(STR."_links.\{linkName}.href", equalTo(requireNonNull(valueIfExists))));
+        } else {
+            result.andExpect(jsonPath(STR."_links.\{linkName}").doesNotExist());
+        }
+    }
+
+    static Stream<Arguments> uniquePagesProvider() {
+        var requestedPageSize = FAKER.random().nextInt(2, 100);
+        var page = lastPage(0, requestedPageSize);
+        return Stream.of(Arguments.of(0, page.getPageable().getPageSize(), page, false, false, false, false));
+    }
+
+    static Stream<Arguments> firstPagesProvider() {
+        var requestedPageSize = FAKER.random().nextInt(2, 100);
+        var page = fullPage(0, requestedPageSize);
+        return Stream.of(Arguments.of(0, page.getPageable().getPageSize(), page, true, false, true, true));
+    }
+
+    static Stream<Arguments> intermediatePagesProvider() {
+        var pageIndex = FAKER.random().nextInt(1, 100);
+        var requestedPageSize = FAKER.random().nextInt(2, 100);
+        var page = fullPage(pageIndex, requestedPageSize);
+        return Stream.of(Arguments.of(page.getNumber(), page.getPageable().getPageSize(), page, true, true, true, true));
+    }
+
+    static Stream<Arguments> lastPagesProvider() {
+        var pageIndex = FAKER.random().nextInt(1, 100);
+        var requestedPageSize = FAKER.random().nextInt(2, 100);
+        var page = lastPage(pageIndex, requestedPageSize);
+        return Stream.of(Arguments.of(page.getNumber(), page.getPageable().getPageSize(), page, true, true, false, true));
+    }
+
+    private static Page<Author> pageSample(int pageIndex, int requestedPageSize) {
+        var isLastPage = FAKER.bool().bool();
+        if (isLastPage) {
+            return lastPage(pageIndex, requestedPageSize);
+        }
+        return fullPage(pageIndex, requestedPageSize);
+    }
+
+    private static PageImpl<Author> lastPage(int page, int requestedPageSize) {
+        int pageSize = FAKER.random().nextInt(1, requestedPageSize);
+        int totalRows = pageSize;
+        if (page > 0) {
+            totalRows += requestedPageSize * page;
+        }
+        var elements = authors(pageSize);
+        return new PageImpl<>(elements, PageRequest.of(page, requestedPageSize), totalRows);
+    }
+
+    private static PageImpl<Author> fullPage(int page, int requestedPageSize) {
+        var totalPages = FAKER.random().nextInt(page + 1, 150);
+        var lastPageSize = FAKER.random().nextInt(1, requestedPageSize - 1);
+        var totalRows = totalPages * requestedPageSize + lastPageSize;
+        var elements = authors(requestedPageSize);
+        return new PageImpl<>(elements, PageRequest.of(page, requestedPageSize), totalRows);
+    }
+
+    public static void assertResponseContainsAllAuthors(ResultActions result, Collection<Author> expectedAuthors) throws Exception {
+        result.andExpect(jsonPath("_embedded.authors").exists())
+                .andExpect(jsonPath("_embedded.authors").isArray())
+                .andExpect(jsonPath("_embedded.authors", hasSize(expectedAuthors.size())));
+        for (var author : expectedAuthors) {
+            if (author.dateOfDeath().isPresent()) {
+                result.andExpect(jsonPath(
+                        "_embedded.authors.[" +
+                                "?(@.id == \"" + author.id() + "\" " +
+                                "&& @.name == \"" + author.name() + "\" " +
+                                "&& @.date_of_birth == \"" + author.dateOfBirth() + "\" " +
+                                "&& @.date_of_death == \"" + author.dateOfDeath().get() + "\" " +
+                                "&& @._links.self.href == \"http://localhost/api/v1/authors/" + author.id() + "\")]").exists());
+            } else {
+                // TODO ensure date of death is not present
+                result.andExpect(jsonPath(
+                        "_embedded.authors.[" +
+                                "?(@.id == \"" + author.id() + "\" " +
+                                "&& @.name == \"" + author.name() + "\" " +
+                                "&& @.date_of_birth == \"" + author.dateOfBirth() + "\" " +
+                                "&& @._links.self.href == \"http://localhost/api/v1/authors/" + author.id() + "\")]").exists());
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("refuse referencing author when name is missing")
+    void referenceAuthorMissingName() throws Exception {
+        var dateOfBirth = Authors.dateOfBirth();
+        mvc.perform(post("/api/v1/authors")
+                        .contentType("application/json")
+                        .content(STR."{\"date_of_birth\":\"\{dateOfBirth}\"}")
+                ).andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("type", equalTo("/problems/invalid-request")))
+                .andExpect(jsonPath("status", equalTo(400)))
+                .andExpect(jsonPath("title", equalTo("Request validation error")))
+                .andExpect(jsonPath("detail", equalTo("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")))
+                .andExpect(jsonPath("errors").isArray())
+                .andExpect(jsonPath("errors", hasSize(1)))
+                .andExpect(jsonPath("errors[0].detail", equalTo("Missing required property")))
+                .andExpect(jsonPath("errors[0].pointer", equalTo("name")));
+    }
+
+    @Test
+    @DisplayName("refuse referencing author when date of birth is missing")
+    void referenceAuthorMissingDateOfBirth() throws Exception {
+        var name = Authors.name();
+        mvc.perform(post("/api/v1/authors")
+                        .contentType("application/json")
+                        .content(STR."{\"name\":\"\{name}\"}")
+                ).andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_PROBLEM_JSON))
+                .andExpect(jsonPath("type", equalTo("/problems/invalid-request")))
+                .andExpect(jsonPath("status", equalTo(400)))
+                .andExpect(jsonPath("title", equalTo("Request validation error")))
+                .andExpect(jsonPath("detail", equalTo("Request parameters or body are invalid compared to the OpenAPI specification. See errors for more information")))
+                .andExpect(jsonPath("errors").isArray())
+                .andExpect(jsonPath("errors", hasSize(1)))
+                .andExpect(jsonPath("errors[0].detail", equalTo("Missing required property")))
+                .andExpect(jsonPath("errors[0].pointer", equalTo("date_of_birth")));
+    }
+
+    @Test
+    @DisplayName("reference alive author successfully when request is valid")
+    void referenceAliveAuthorSuccess() throws Exception {
+        var author = builder().alive().build();
+
+        when(authorsReferencingService.referenceAuthor(any())).thenReturn(author);
+
+        mvc.perform(post("/api/v1/authors")
+                        .contentType("application/json")
+                        .content(STR."{\"name\":\"\{author.name()}\", \"date_of_birth\":\"\{author.dateOfBirth()}\"}")
+                ).andExpect(status().isCreated())
+                .andExpect(header().string("Location", equalTo(STR."http://localhost/api/v1/authors/\{author.id()}")))
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("id", equalTo(author.id().toString())))
+                .andExpect(jsonPath("name", equalTo(author.name())))
+                .andExpect(jsonPath("date_of_birth", equalTo(author.dateOfBirth().toString())))
+                .andExpect(jsonPath("date_of_death").doesNotExist())
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/authors/\{author.id()}")));
+
+        verify(authorsReferencingService).referenceAuthor(referenceCommandCaptor.capture());
+        var actual = referenceCommandCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.name()).isEqualTo(author.name());
+            s.assertThat(actual.dateOfBirth()).isEqualTo(author.dateOfBirth());
+        });
+    }
+
+    @Test
+    @DisplayName("reference dead author successfully when request is valid")
+    void referenceDeadAuthorSuccess() throws Exception {
+        var author = builder().dead().build();
+
+        when(authorsReferencingService.referenceAuthor(any())).thenReturn(author);
+
+        mvc.perform(post("/api/v1/authors")
+                        .contentType("application/json")
+                        .content(STR."{\"name\":\"\{author.name()}\", \"date_of_birth\":\"\{author.dateOfBirth()}\", \"date_of_death\":\"\{author.dateOfDeath().orElseThrow()}\"}")
+                ).andExpect(status().isCreated())
+                .andExpect(header().string("Location", equalTo(STR."http://localhost/api/v1/authors/\{author.id()}")))
+                .andExpect(content().contentTypeCompatibleWith("application/hal+json"))
+                .andExpect(jsonPath("id", equalTo(author.id().toString())))
+                .andExpect(jsonPath("name", equalTo(author.name())))
+                .andExpect(jsonPath("date_of_birth", equalTo(author.dateOfBirth().toString())))
+                .andExpect(jsonPath("date_of_death", equalTo(author.dateOfDeath().orElseThrow().toString())))
+                .andExpect(jsonPath("_links.self.href", equalTo(STR."http://localhost/api/v1/authors/\{author.id()}")));
+
+        verify(authorsReferencingService).referenceAuthor(referenceCommandCaptor.capture());
+        var actual = referenceCommandCaptor.getValue();
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(actual.name()).isEqualTo(author.name());
+            s.assertThat(actual.dateOfBirth()).isEqualTo(author.dateOfBirth());
+            s.assertThat(actual.dateOfDeath()).isEqualTo(author.dateOfDeath());
+        });
+    }
+
+}

--- a/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsConsultationServiceTests.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsConsultationServiceTests.java
@@ -1,0 +1,136 @@
+package org.adhuc.library.referencing.authors;
+
+import org.adhuc.library.referencing.authors.internal.InMemoryAuthorsRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.adhuc.library.referencing.authors.AuthorsMother.authors;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Authors consultation service should")
+class AuthorsConsultationServiceTests {
+
+    private InMemoryAuthorsRepository authorsRepository;
+    private AuthorsConsultationService service;
+
+    @BeforeEach
+    void setUp() {
+        authorsRepository = new InMemoryAuthorsRepository();
+        service = new AuthorsConsultationService(authorsRepository);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, 10",
+            "0, 50",
+            "10, 50"
+    })
+    @DisplayName("return an empty page when no author is referenced yet")
+    void getEmptyPageNoAuthorReferenced(int number, int size) {
+        var page = service.getPage(PageRequest.of(number, size));
+        assertThat(page.isEmpty()).isTrue();
+    }
+
+    @Nested
+    @DisplayName("when 53 authors have been referenced")
+    class BooksInCatalogTests {
+
+        private static final List<Author> AUTHORS = new ArrayList<>();
+
+        @BeforeAll
+        static void initAuthors() {
+            var authors = authors(53);
+            AUTHORS.addAll(authors);
+        }
+
+        @BeforeEach
+        void setUp() {
+            authorsRepository.saveAll(AUTHORS);
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "0, 10, 6, 53",
+                "1, 10, 6, 53",
+                "4, 10, 6, 53",
+                "0, 25, 3, 53",
+                "1, 25, 3, 53",
+                "0, 50, 2, 53",
+                "0, 53, 1, 53",
+                "0, 37, 2, 53"
+        })
+        @DisplayName("return a full page of authors when requested page is not beyond the total number of referenced authors")
+        void getFullPage(int number, int size, int totalPages, int totalElements) {
+            var page = service.getPage(PageRequest.of(number, size));
+            SoftAssertions.assertSoftly(s -> {
+                s.assertThat(page.isEmpty()).isFalse();
+                s.assertThat(page.getNumber()).isEqualTo(number);
+                s.assertThat(page.getSize()).isEqualTo(size);
+                s.assertThat(page.getNumberOfElements()).isEqualTo(size);
+                s.assertThat(page.getTotalPages()).isEqualTo(totalPages);
+                s.assertThat(page.getTotalElements()).isEqualTo(totalElements);
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "5, 10, 3, 6, 53",
+                "2, 25, 3, 3, 53",
+                "1, 50, 3, 2, 53",
+                "0, 100, 53, 1, 53",
+                "1, 37, 16, 2, 53"
+        })
+        @DisplayName("return a partial page of authors when requested page reaches the total number of referenced authors")
+        void getPartialPage(int number, int size, int elements, int totalPages, int totalElements) {
+            var page = service.getPage(PageRequest.of(number, size));
+            SoftAssertions.assertSoftly(s -> {
+                s.assertThat(page.isEmpty()).isFalse();
+                s.assertThat(page.getNumber()).isEqualTo(number);
+                s.assertThat(page.getSize()).isEqualTo(size);
+                s.assertThat(page.getNumberOfElements()).isEqualTo(elements);
+                s.assertThat(page.getTotalPages()).isEqualTo(totalPages);
+                s.assertThat(page.getTotalElements()).isEqualTo(totalElements);
+            });
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "6, 10",
+                "3, 25",
+                "2, 50",
+                "1, 100",
+                "1, 53",
+                "2, 37"
+        })
+        @DisplayName("return an empty page of books when requested page is beyond the total number of referenced authors")
+        void getEmptyPageBeyondSize(int number, int size) {
+            var page = service.getPage(PageRequest.of(number, size));
+            assertThat(page.isEmpty()).isTrue();
+        }
+
+        @ParameterizedTest
+        @CsvSource({
+                "6, 10",
+                "3, 25",
+                "2, 50",
+                "1, 100"
+        })
+        @DisplayName("provide the complete list of authors when browsing all the pages")
+        void browsePagesAllAuthors(int numberOfPages, int pageSize) {
+            var authors = new HashSet<Author>();
+            for (int pageNumber = 0; pageNumber < numberOfPages; pageNumber++) {
+                authors.addAll(service.getPage(PageRequest.of(pageNumber, pageSize)).getContent());
+            }
+            assertThat(authors.size()).isEqualTo(53);
+        }
+
+    }
+
+}

--- a/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsMother.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsMother.java
@@ -1,0 +1,124 @@
+package org.adhuc.library.referencing.authors;
+
+import net.datafaker.Faker;
+import org.jspecify.annotations.Nullable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.IntStream;
+
+import static java.time.LocalDate.now;
+import static java.time.ZoneId.systemDefault;
+import static java.time.ZoneOffset.UTC;
+import static org.adhuc.library.referencing.authors.AuthorsMother.Authors.aliveDateOfBirth;
+import static org.adhuc.library.referencing.authors.AuthorsMother.Authors.deadDateOfDeath;
+
+public class AuthorsMother {
+
+    public static List<Author> authors(int size) {
+        return IntStream.range(0, size)
+                .mapToObj(_ -> author())
+                .toList();
+    }
+
+    public static Author author() {
+        var dateOfBirth = Authors.dateOfBirth();
+        return new Author(
+                Authors.id(),
+                Authors.name(),
+                dateOfBirth,
+                Authors.dateOfDeath(dateOfBirth)
+        );
+    }
+
+    public static AuthorBuilder builder() {
+        return new AuthorBuilder();
+    }
+
+    public static final class Authors {
+        private static final int MINIMAL_AGE = 15;
+        private static final int MAXIMAL_AGE = 100;
+        private static final Faker FAKER = new Faker();
+
+        public static UUID id() {
+            return UUID.randomUUID();
+        }
+
+        public static String name() {
+            return FAKER.book().author();
+        }
+
+        public static LocalDate dateOfBirth() {
+            return FAKER.timeAndDate().birthday();
+        }
+
+        public static LocalDate aliveDateOfBirth() {
+            return FAKER.timeAndDate().birthday(MINIMAL_AGE, MAXIMAL_AGE);
+        }
+
+        @Nullable
+        public static LocalDate dateOfDeath(LocalDate dateOfBirth) {
+            var canBeAlive = dateOfBirth.isAfter(now().minusYears(100));
+            var isAlive = canBeAlive && FAKER.bool().bool();
+            if (isAlive) {
+                return null;
+            }
+            var maxDateOfDeath = canBeAlive ? now() : dateOfBirth.plusYears(MAXIMAL_AGE);
+            return FAKER.timeAndDate().between(
+                    dateOfBirth.plusYears(MINIMAL_AGE).atStartOfDay().toInstant(UTC),
+                    maxDateOfDeath.atStartOfDay().toInstant(UTC)
+            ).atZone(systemDefault()).toLocalDate();
+        }
+
+        public static LocalDate deadDateOfDeath(LocalDate dateOfBirth) {
+            var canBeAlive = dateOfBirth.isAfter(now().minusYears(100));
+            var maxDateOfDeath = canBeAlive ? now() : dateOfBirth.plusYears(MAXIMAL_AGE);
+            return FAKER.timeAndDate().between(
+                    dateOfBirth.plusYears(MINIMAL_AGE).atStartOfDay().toInstant(UTC),
+                    maxDateOfDeath.atStartOfDay().toInstant(UTC)
+            ).atZone(systemDefault()).toLocalDate();
+        }
+    }
+
+    public static class AuthorBuilder {
+        private Author author = author();
+
+        public AuthorBuilder id(UUID id) {
+            author = new Author(id, author.name(), author.dateOfBirth(), author.dateOfDeath().orElse(null));
+            return this;
+        }
+
+        public AuthorBuilder name(String name) {
+            author = new Author(author.id(), name, author.dateOfBirth(), author.dateOfDeath().orElse(null));
+            return this;
+        }
+
+        public AuthorBuilder dateOfBirth(LocalDate dateOfBirth) {
+            author = new Author(author.id(), author.name(), dateOfBirth, author.dateOfDeath().orElse(null));
+            return this;
+        }
+
+        public AuthorBuilder alive() {
+            var dateOfBirth = aliveDateOfBirth();
+            author = new Author(author.id(), author.name(), dateOfBirth, null);
+            return this;
+        }
+
+        public AuthorBuilder dateOfDeath(@Nullable LocalDate dateOfDeath) {
+            author = new Author(author.id(), author.name(), author.dateOfBirth(), dateOfDeath);
+            return this;
+        }
+
+        public AuthorBuilder dead() {
+            var dateOfDeath = deadDateOfDeath(author.dateOfBirth());
+            author = new Author(author.id(), author.name(), author.dateOfBirth(), dateOfDeath);
+            return this;
+        }
+
+        public Author build() {
+            return author;
+        }
+    }
+
+}

--- a/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsReferencingServiceTests.java
+++ b/referencing/src/test/java/org/adhuc/library/referencing/authors/AuthorsReferencingServiceTests.java
@@ -1,0 +1,68 @@
+package org.adhuc.library.referencing.authors;
+
+import org.adhuc.library.referencing.authors.AuthorsMother.Authors;
+import org.adhuc.library.referencing.authors.internal.InMemoryAuthorsRepository;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("Authors referencing service should")
+class AuthorsReferencingServiceTests {
+
+    private InMemoryAuthorsRepository authorsRepository;
+    private AuthorsReferencingService service;
+
+    @BeforeEach
+    void setUp() {
+        authorsRepository = new InMemoryAuthorsRepository();
+        service = new AuthorsReferencingService(authorsRepository);
+    }
+
+    @Test
+    @DisplayName("reference alive author, providing an author with generated ID")
+    void referenceAliveAuthor() {
+        var name = Authors.name();
+        var dateOfBirth = Authors.aliveDateOfBirth();
+        var command = new ReferenceAuthor(name, dateOfBirth);
+        var author = service.referenceAuthor(command);
+
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(author.id()).isNotNull();
+            s.assertThat(author.name()).isEqualTo(name);
+            s.assertThat(author.dateOfBirth()).isEqualTo(dateOfBirth);
+            s.assertThat(author.dateOfDeath()).isNotPresent();
+        });
+    }
+
+    @Test
+    @DisplayName("reference dead author, providing an author with generated ID")
+    void referenceDeadAuthor() {
+        var name = Authors.name();
+        var dateOfBirth = Authors.dateOfBirth();
+        var dateOfDeath = Authors.deadDateOfDeath(dateOfBirth);
+        var command = new ReferenceAuthor(name, dateOfBirth, dateOfDeath);
+        var author = service.referenceAuthor(command);
+
+        SoftAssertions.assertSoftly(s -> {
+            s.assertThat(author.id()).isNotNull();
+            s.assertThat(author.name()).isEqualTo(name);
+            s.assertThat(author.dateOfBirth()).isEqualTo(dateOfBirth);
+            s.assertThat(author.dateOfDeath()).isPresent().contains(dateOfDeath);
+        });
+    }
+
+    @Test
+    @DisplayName("save author when referencing it")
+    void referenceAuthorSaveIt() {
+        var name = Authors.name();
+        var dateOfBirth = Authors.dateOfBirth();
+        var command = new ReferenceAuthor(name, dateOfBirth);
+        var author = service.referenceAuthor(command);
+
+        assertThat(authorsRepository.findById(author.id())).isPresent().contains(author);
+    }
+
+}


### PR DESCRIPTION
This feature implements the same approach for OpenAPI validation as the catalog service, that was duplicated. A next development will extract the validation feature in a dedicated shared library.